### PR TITLE
Remove bad implication IsLinearCodeRep => IsCodeDefaultRep

### DIFF
--- a/lib/codegen.gi
+++ b/lib/codegen.gi
@@ -41,7 +41,6 @@ DeclareRepresentation( "IsCodeDefaultRep",
 
 DeclareHandlingByNiceBasis( "IsLinearCodeRep", "for linear codes" );
 
-InstallTrueMethod( IsCodeDefaultRep, IsLinearCodeRep );
 InstallTrueMethod( IsLinearCode, IsLinearCodeRep );
 
 #T The following is of course a hack, as is much of the
@@ -115,7 +114,7 @@ LinearCodeByGenerators := function(F, gens)
     local V;
     V:= Objectify( NewType( FamilyObj( gens ),
                             IsLeftModule and 
-			    IsLinearCodeRep ),
+			    IsLinearCodeRep and IsCodeDefaultRep ),
                    rec() );
     SetLeftActingDomain( V, F );
     SetGeneratorsOfLeftModule( V, AsList( One(F)*gens ) );


### PR DESCRIPTION
Despite its misleading name, IsLinearCodeRep is not a representation but rather a plain filter. As such, it should not imply a representation, as any object, with an arbitrary representation, may have this filter set.

Besides removing the implication, we also need to adjust code that relied on it before.

In future GAP versions, such implications may become illegal, see <https://github.com/gap-system/gap/pull/3006>.

BTW, I would also recommend renaming `IsLinearCodeRep`, replacing the misleading `Rep` suffix.