### PR TITLE
PackageInfo.g: add License field

### DIFF
--- a/COPYING.guava
+++ b/COPYING.guava
@@ -1,5 +1,5 @@
 There are 2 parts to this software, both of which are now GPL'd.
-You may use version 2 or version 3 (at your preference).
+You may use version 2 or later.
 
 Part 1: Leon's C code.
 

--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -9,7 +9,8 @@ SetPackageInfo( rec(
   PackageName := "GUAVA",
   Subtitle := "a GAP package for computing with error-correcting codes",
   Version := "3.14",
-  Date    := "24/03/2018",
+  Date    := "24/03/2018", # dd/mm/yyyy format
+  License := "GPL-2.0-or-later",
   SourceRepository := rec(
     Type := "git",
     URL := Concatenation( 


### PR DESCRIPTION
However, I am not completely sure if the value is correct: I set it to "GPL 2 or later", which is what GAP itself uses, and the majority of all packages. It is also what `doc/guava.xml` indicates. But in the COPYING file, it says "version 2 or version 3".

It would be good to settle on one, and then ensure it is documented consistently.