### PR TITLE
Update Travis integration, test on macOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,24 @@
 language: c
-env:
-  global:
-    - GAPROOT=gaproot
-    - COVDIR=coverage
 
 addons:
   apt_packages:
     - libgmp-dev
     - libreadline-dev
-    - libgmp-dev:i386
-    - libreadline-dev:i386
-    - gcc-multilib
-    - g++-multilib
+    - zlib1g-dev
 
 matrix:
   include:
     - env: GAPBRANCH=master ABI=64
     - env: GAPBRANCH=master ABI=32
+      addons:
+        apt_packages:
+          - libgmp-dev:i386
+          - libreadline-dev:i386
+          - zlib1g-dev:i386
+          - gcc-multilib
+          - g++-multilib
+    - env: GAPBRANCH=master
+      os: osx
     - env: GAPBRANCH=stable-4.9
     - env: GAPBRANCH=stable-4.10
 
@@ -25,11 +27,10 @@ branches:
     - master
 
 before_script:
-  - export GAPROOT="$HOME/gap"
   - git clone https://github.com/gap-system/pkg-ci-scripts.git scripts
   - scripts/build_gap.sh
 script:
   - scripts/build_pkg.sh && scripts/run_tests.sh
 after_script:
-  - bash scripts/gather-coverage.sh
+  - scripts/gather-coverage.sh
   - bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
I have no idea (yet) how to test on Windows with Travis, though; so far we always used AppVeyor for that, though it would certainly be nice to also use Travis for it, if only because it's easier to learn and remember how to use one service than two.

This partially addresses issue #40