### PR TITLE
Add Travis and Codecov badges to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+[![Build Status](https://travis-ci.org/gap-packages/guava.svg?branch=master)](https://travis-ci.org/gap-packages/guava)
+[![Code Coverage](https://codecov.io/github/gap-packages/guava/coverage.svg?branch=master&token=)](https://codecov.io/gh/gap-packages/guava)
+
 guava
 =====
 


### PR DESCRIPTION
@osj1961 This will display the status and will allow to click on the badge to easily find logs and reports.

You can see the intended result in the README displayed at https://github.com/gap-packages/guava/tree/alex-konovalov-patch-1