### PR TITLE
autogen.sh: suppress automake output

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -8,5 +8,5 @@ autoheader
 # WORKAROUND: invoke automake (even though we don't use it) to ensure
 # that `install-sh` gets added; this works around a bug in older
 # versions of GNU autotools.
-automake --force-missing --add-missing --copy || :
+automake --force-missing --add-missing --copy >/dev/null 2>&1  || :
 autoconf


### PR DESCRIPTION
Newer versions complain about the hack for installing install-sh,
but do it anyway. So we just silence those misleading errors
