### PR TITLE
PackageInfo.g: remove obsolete Autoload flag

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -283,13 +283,6 @@ SetPackageInfo( rec(
     end,
 
 
-##  Suggest here if the package should be *automatically loaded* when GAP is 
-##  started.  This should usually be 'false'. Say 'true' only if your package 
-##  provides some improvements of the GAP library which are likely to enhance 
-##  the overall system performance for many users.
-
-  Autoload := false,
-
 ##  *Optional*, but recommended: path relative to package root to a file which 
 ##  contains as many tests of the package functionality as sensible.
 TestFile := "tst/guava.tst",


### PR DESCRIPTION
This flag is (and always was) ignored by GAP and having it here is
potentially misleading
