### PR TITLE
Fix PutStandardForm *again*

### DIFF
--- a/lib/matrices.gi
+++ b/lib/matrices.gi
@@ -637,7 +637,7 @@ InstallOtherMethod(PutStandardForm, "method for matrix and Field", true,
 function(mat, F) 
 local perm, k, i, j, d ;
  d := Length(mat[1]);
- mat:=TriangulizeMat(mat); #this was TriangulizedMat which seems to be an error
+ TriangulizeMat(mat);
  perm := ();
  k := Length(mat[1]);
  for i in [1..Length(mat)] do

--- a/tst/bugfix.tst
+++ b/tst/bugfix.tst
@@ -1,0 +1,22 @@
+gap> C1 := BestKnownLinearCode( 23, 12, GF(2) );
+a linear [23,12,7]3 punctured code
+gap> C1 = BinaryGolayCode();
+false
+gap> C1 := BestKnownLinearCode( 23, 12, GF(2) );
+a linear [23,12,7]3 punctured code
+gap> G1 := MutableCopyMat(GeneratorMat(C1));;
+gap> PutStandardForm(G1);
+()
+gap> Display(G1);
+ 1 . . . . . . . . . . . 1 . 1 . 1 1 1 . . . 1
+ . 1 . . . . . . . . . . 1 1 1 1 1 . . 1 . . .
+ . . 1 . . . . . . . . . 1 1 . 1 . . 1 . 1 . 1
+ . . . 1 . . . . . . . . 1 1 . . . 1 1 1 . 1 .
+ . . . . 1 . . . . . . . 1 1 . . 1 1 . 1 1 . 1
+ . . . . . 1 . . . . . . . 1 1 . . 1 1 . 1 1 1
+ . . . . . . 1 . . . . . . . 1 1 . . 1 1 . 1 1
+ . . . . . . . 1 . . . . 1 . 1 1 . 1 1 1 1 . .
+ . . . . . . . . 1 . . . . 1 . 1 1 . 1 1 1 1 .
+ . . . . . . . . . 1 . . . . 1 . 1 1 . 1 1 1 .
+ . . . . . . . . . . 1 . 1 . 1 1 1 . . . 1 1 1
+ . . . . . . . . . . . 1 . 1 . 1 1 1 . . . 1 1


### PR DESCRIPTION
Commit 8474420b5faf7469e841e6e3674bed0e050db0c6 was meant to "fix"
`PutStandardForm` according to the commit message, although it is
not specified what it was supposed to fix.

This led to changed behavior of `PutStandardForm`. This was meant
to be fixed by c2b498f3d1635410c48461e3c8300752764b8c7d but it was
incorrect, too, now immediately leading to errors (it tried to use
the return value of `TriangulizeMat`, but this procedure never returns
anything)

Let's hope that three is the charm...

Fixes #53 essentially in exactly the way already suggested in a comment there from 2020.