### PR TITLE
Fix out of bounds access in the C code

### DIFF
--- a/src/leon/src/stcs.c
+++ b/src/leon/src/stcs.c
@@ -461,7 +461,7 @@ static BOOLEAN checkStabilizer(
                        (wh.word.length + symmetricWordLength(&wh.word));
             if ( relatorPriority > selectionPriority ) {
                newRel = addRelatorSortedFromWord( G, &wh.word, TRUE, TRUE);
-               selectionPriority += relatorSelection[4];
+               selectionPriority += relatorSelection[3];
                ++numberSelected;
                totalSelectedLength += newRel->length;
                numberAdded = addOccurencesForRelator( newRel,
@@ -470,7 +470,7 @@ static BOOLEAN checkStabilizer(
                traceNewRelator( G, level, deductionQueue, newRel);
             }
             else
-               selectionPriority -= relatorSelection[5];
+               selectionPriority -= relatorSelection[4];
             ++numberOfRelators;
             totalRelatorLength += wh.word.length;
             maxRelatorLength = MAX ( maxRelatorLength, wh.word.length);
@@ -640,7 +640,7 @@ static BOOLEAN xCheckStabilizer(
                               ((*wPtr)->length + symmetricWordLength(*wPtr));
                if ( relatorPriority > selectionPriority ) {
                   newRel = addRelatorSortedFromWord( G, *wPtr, TRUE, TRUE);
-                  selectionPriority += relatorSelection[4];
+                  selectionPriority += relatorSelection[3];
                   ++numberSelected;
                   totalSelectedLength += newRel->length;
                   numberAdded = addOccurencesForRelator( newRel,
@@ -649,7 +649,7 @@ static BOOLEAN xCheckStabilizer(
                   traceNewRelator( G, level, deductionQueue, newRel);
                }
                else
-                  selectionPriority -= relatorSelection[5];
+                  selectionPriority -= relatorSelection[4];
                ++numberOfRelators;
                totalRelatorLength += (*wPtr)->length;
                maxRelatorLength = MAX ( maxRelatorLength, (*wPtr)->length);


### PR DESCRIPTION
A compiler warning flagged this one: the global array relatorSelection has
length 5, but the code tried to access `relatorSelection[5]` which would be
the 6th element, as C uses 0-based indexing.

Upon inspecting the code, it also became clear that `relatorSelection[3]`
never is accessed, and that access to `relatorSelection[4]` and
`relatorSelection[5]` only occur together, in two places, and both are
used to modify `selectionPriority`.

Based on this, I believe both of those were off-by-one, and adjusted the code
accordingly
