### PR TITLE
Fix priority computation in the C code (changes behavior based on guess work)

### DIFF
--- a/src/leon/src/ccent.c
+++ b/src/leon/src/ccent.c
@@ -86,7 +86,7 @@ static UnsignedS nextBasePointEltCent(
    for ( pt = 1 ; pt <= degree ; ++pt )
       if ( (cSize = cellSize[cellNumber[pt]]) > 1 ) {
          if ( longCycleFlag )
-            priority = 2000000000ul - (unsigned long) MIN(cycleLen[pt],1000) << 20 
+            priority = 2000000000ul - ((unsigned long) MIN(cycleLen[pt],1000) << 20) 
                        + cSize;
          else
             if ( cycleLen[pt] == 1 ) 


### PR DESCRIPTION
(Alternative to PR #83)

This fixes another C compiler warning:

    ./src/ccent.c:89:37: warning: operator '<<' has lower precedence than '-'; '-' will be evaluated first [-Wshift-op-parentheses]
                priority = 2000000000ul - (unsigned long) MIN(cycleLen[pt],1000) << 20
                           ~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ~~
    ./src/ccent.c:89:37: note: place parentheses around the '-' expression to silence this warning
                priority = 2000000000ul - (unsigned long) MIN(cycleLen[pt],1000) << 20
                           ~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    ./src/ccent.c:90:24: warning: operator '<<' has lower precedence than '+'; '+' will be evaluated first [-Wshift-op-parentheses]
                           + cSize;
                           ^~~~~~~
    ./src/ccent.c:90:24: note: place parentheses around the '+' expression to silence this warning
                           + cSize;
                           ^
                                  )

So the code used to first compute `2000000000 - MIN(cycleLen[pt],1000)`, *then*
computed `20 + cSize`, and finally performed a shift. But shifting such a larger
number by 20 or more causes an overflow. That seems weird...

On the other hand, if we assume that the real intent was to first compute
`MIN(cycleLen[pt],1000) << 20`, then we notice that `1000 << 20` is close
to `2000000000` (indeed, it is the largest shift still smaller than that)
number. So then the cycleLen would affect the upper bits, and finally cSize
is added and affects the lower bits.

Alas this is just a theory based on circumstance -- I don't actually know
what is right, nor how to check it :-()
