### PR TITLE
Fix priority computation in the C code (preserve behavior)

### DIFF
--- a/src/leon/src/ccent.c
+++ b/src/leon/src/ccent.c
@@ -86,8 +86,8 @@ static UnsignedS nextBasePointEltCent(
    for ( pt = 1 ; pt <= degree ; ++pt )
       if ( (cSize = cellSize[cellNumber[pt]]) > 1 ) {
          if ( longCycleFlag )
-            priority = 2000000000ul - (unsigned long) MIN(cycleLen[pt],1000) << 20 
-                       + cSize;
+            priority = (2000000000ul - (unsigned long) MIN(cycleLen[pt],1000))
+                        << (20 + cSize);
          else
             if ( cycleLen[pt] == 1 ) 
                priority = cSize;


### PR DESCRIPTION
(Alternative to PR #82)

This fixes another C compiler warning:

    ./src/ccent.c:89:37: warning: operator '<<' has lower precedence than '-'; '-' will be evaluated first [-Wshift-op-parentheses]
                priority = 2000000000ul - (unsigned long) MIN(cycleLen[pt],1000) << 20
                           ~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ~~
    ./src/ccent.c:89:37: note: place parentheses around the '-' expression to silence this warning
                priority = 2000000000ul - (unsigned long) MIN(cycleLen[pt],1000) << 20
                           ~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    ./src/ccent.c:90:24: warning: operator '<<' has lower precedence than '+'; '+' will be evaluated first [-Wshift-op-parentheses]
                           + cSize;
                           ^~~~~~~
    ./src/ccent.c:90:24: note: place parentheses around the '+' expression to silence this warning
                           + cSize;
                           ^
                                  )

This patch adds parenthesis to silence the warnings, thus preserving the
current behavior. Whether this is the correct way to fix the warning remains
unclear...
