### PR TITLE
Fix input/output handling of subprocesses

### DIFF
--- a/lib/codeman.gi
+++ b/lib/codeman.gi
@@ -406,16 +406,16 @@ function(C, wt)
       GuavaToLeon(C, incode);
       Process(DirectoryCurrent(),
          Filename(DirectoriesPackagePrograms("guava"), "wtdist"),
-	 InputTextUser(),
-	 OutputTextUser(),
+	 InputTextNone(),
+	 OutputTextNone(),
 	 ["-q",  Concatenation(incode,"::code"), wt,
 	  Concatenation(cwsc,"::code")]
       );
       if IsReadableFile( cwsc ) then
          Process(DirectoryCurrent(),
               Filename(DirectoriesPackagePrograms("guava"), "leonconv"),
-              InputTextUser(),
-              OutputTextUser(),
+              InputTextNone(),
+              OutputTextNone(),
               ["-c", cwsc, infile]
          );
       else

--- a/lib/codeops.gi
+++ b/lib/codeops.gi
@@ -1709,8 +1709,8 @@ function(C)
     GuavaToLeon(Ccalc, incode);
     Process(DirectoryCurrent(),
             Filename(path, "wtdist"),
-            InputTextUser(),
-            OutputTextUser(),
+            InputTextNone(),
+            OutputTextNone(),
             ["-q", Concatenation(incode,"::code"), MinimumDistance(Ccalc), Concatenation(inV, "::code")]
     );
     #Exec(Filename(DirectoriesPackagePrograms("guava"), "wtdist"),
@@ -1718,8 +1718,8 @@ function(C)
     #        String(MinimumDistance(Ccalc))," ",inV,"::code"));
     Process(DirectoryCurrent(),
             Filename(path, "desauto"),
-            InputTextUser(),
-            OutputTextUser(),
+            InputTextNone(),
+            OutputTextNone(),
             ["-code", "-q", Concatenation(incode,"::code"), Concatenation(inV, "::code"), outgroup]
     );
     #Exec(Filename(DirectoriesPackagePrograms("guava"), "desauto"),
@@ -1727,8 +1727,8 @@ function(C)
     #        incode,"::code ",inV,"::code ",outgroup));
     Process(DirectoryCurrent(),
             Filename(path, "leonconv"),
-            InputTextUser(),
-            OutputTextUser(),
+            InputTextNone(),
+            OutputTextNone(),
             ["-a", outgroup, infile]
     );
     #Exec(Filename(DirectoriesPackagePrograms("guava"), "leonconv"),
@@ -2016,8 +2016,8 @@ function(C1, C2)
     #        String(MinimumDistance(C1))," ",cwcode1,"::code"));
     Process(DirectoryCurrent(),
             Filename(DirectoriesPackagePrograms("guava"), "wtdist"),
-            InputTextUser(),
-            OutputTextUser(),
+            InputTextNone(),
+            OutputTextNone(),
             ["-q", Concatenation(code1,"::code"),
              MinimumDistance(C1), Concatenation(cwcode1, "::code")]
     );
@@ -2026,8 +2026,8 @@ function(C1, C2)
     #        String(MinimumDistance(C2))," ",cwcode2,"::code"));
     Process(DirectoryCurrent(),
             Filename(DirectoriesPackagePrograms("guava"), "wtdist"),
-            InputTextUser(),
-            OutputTextUser(),
+            InputTextNone(),
+            OutputTextNone(),
             ["-q", Concatenation(code2,"::code"),
              MinimumDistance(C2), Concatenation(cwcode2, "::code")]
     );
@@ -2037,8 +2037,8 @@ function(C1, C2)
     #        cwcode2,"::code ",output));
     Process(DirectoryCurrent(),
             Filename(DirectoriesPackagePrograms("guava"), "desauto"),
-            InputTextUser(),
-            OutputTextUser(),
+            InputTextNone(),
+            OutputTextNone(),
             ["-iso", "-code", "-q",
              Concatenation(code1,"::code"),
              Concatenation(code2,"::code"),
@@ -2051,8 +2051,8 @@ function(C1, C2)
     #        infile));
     Process(DirectoryCurrent(),
             Filename(DirectoriesPackagePrograms("guava"), "leonconv"),
-            InputTextUser(),
-            OutputTextUser(),
+            InputTextNone(),
+            OutputTextNone(),
             ["-e", output, infile]
     );
     Read(infile);
@@ -2809,8 +2809,8 @@ function(C)
 
         Process(DirectoryCurrent(),
             Filename(path, "minimum-weight"),
-            InputTextUser(),
-            OutputTextUser(),
+            InputTextNone(),
+            OutputTextNone(),
             param
         );
     Read(tmpOutFile);


### PR DESCRIPTION
- don't pass on user input to subprocesses (while in practice none of them
should be processing any, there is no point in taking a risk?)

- don't print output of subprocesses to the terminal

Resolves #73

An alternative would be to use `OutputTextString` instead of `OutputTextNone` to capture output and show it if some `InfoLevel` is set suitably high. That might be helpful for debugging in some cases?