### PR TITLE
Use TmpName instead of TmpNameAllArchs

### DIFF
--- a/lib/codeman.gi
+++ b/lib/codeman.gi
@@ -398,10 +398,10 @@ function(C, wt)
       return CWS;
    else
       #Print("the C code programs are compiled, so using Leon's binary....\n");
-      incode := TmpNameAllArchs();
+      incode := TmpName();
       PrintTo( incode, "\n" );
-      infile := TmpNameAllArchs();
-      cwsc := TmpNameAllArchs();
+      infile := TmpName();
+      cwsc := TmpName();
       PrintTo( infile, "\n" );
       GuavaToLeon(C, incode);
       Process(DirectoryCurrent(),

--- a/lib/codeops.gi
+++ b/lib/codeops.gi
@@ -1696,10 +1696,10 @@ function(C)
         Print("... automatically switching to PermutationGroup ...\n");
         return PermutationGroup(C);
     fi;
-    incode :=  TmpNameAllArchs(); PrintTo( incode, "\n" );
-    inV := TmpNameAllArchs(); PrintTo( inV, "\n" );
-    outgroup := TmpNameAllArchs(); PrintTo( outgroup, "\n" );
-    infile := TmpNameAllArchs(); PrintTo( infile, "\n" );
+    incode :=  TmpName(); PrintTo( incode, "\n" );
+    inV := TmpName(); PrintTo( inV, "\n" );
+    outgroup := TmpName(); PrintTo( outgroup, "\n" );
+    infile := TmpName(); PrintTo( infile, "\n" );
     # Calculate with dual code if it is smaller:
     if Dimension(C) > QuoInt(WordLength(C), 2) then
         Ccalc := DualCode(C);
@@ -2003,12 +2003,12 @@ function(C1, C2)
         Error("GUAVA can only calculate equivalence over GF(2)");
     fi;
 
-    code1 := TmpNameAllArchs(); PrintTo( code1, "\n" );
-    code2 := TmpNameAllArchs(); PrintTo( code2, "\n" );
-    cwcode1 := TmpNameAllArchs(); PrintTo( cwcode1, "\n" );
-    cwcode2 := TmpNameAllArchs(); PrintTo( cwcode2, "\n" );
-    output := TmpNameAllArchs(); PrintTo( output, "\n" );
-    infile := TmpNameAllArchs(); PrintTo( infile, "\n" );
+    code1 := TmpName(); PrintTo( code1, "\n" );
+    code2 := TmpName(); PrintTo( code2, "\n" );
+    cwcode1 := TmpName(); PrintTo( cwcode1, "\n" );
+    cwcode2 := TmpName(); PrintTo( cwcode2, "\n" );
+    output := TmpName(); PrintTo( output, "\n" );
+    infile := TmpName(); PrintTo( infile, "\n" );
     GuavaToLeon(C1, code1);
     GuavaToLeon(C2, code2);
     #Exec(Filename(DirectoriesPackagePrograms("guava"), "wtdist"),
@@ -2754,7 +2754,7 @@ function(C)
     k := DimensionsMat(G)[1];
     n := DimensionsMat(G)[2];
     #path := DirectoriesPackagePrograms( "guava" );; #seems unnecessary -- already done above...
-    tmpFile := TmpNameAllArchs(); tmpOutFile := TmpNameAllArchs();
+    tmpFile := TmpName(); tmpOutFile := TmpName();
 
     PrintTo(tmpFile, k, " ", n, " ", Size(LeftActingDomain(C)), "\n");
     for r in [1..k] do;


### PR DESCRIPTION
There are only differences between the two in older GAP versions, and
only in Cygwin. In recent GAP versions, the latter is just an alias for
the former, and `TmpNameAllArchs` has been deprecated. Indeed guava is
the last package still using it.
