### PR TITLE
Switch makedoc.g to use AutoDoc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,8 @@ Makefile
 /doc/*.six
 /doc/*.tex
 /doc/*.toc
+/doc/_*.xml
+/doc/title.xml
 /doc/manual.pdf
 /doc/guava_bib.xml.bib
 

--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -260,7 +260,23 @@ TestFile := "tst/guava.tst",
 "nonlinear code","minimum distance", "minimum weight", 
 "error-correcting block codes", "decoding",
 "generator matrix", "check matrix","covering radius", 
-"weight distribution","automorphism group of code" ]
+"weight distribution","automorphism group of code" ],
+
+AutoDoc := rec(
+    entities := rec(
+        VERSION := ~.Version,
+        RELEASEDATE := function(date)
+          local day, month, year, allMonths;
+          day := Int(date{[1,2]});
+          month := Int(date{[4,5]});
+          year := Int(date{[7..10]});
+          allMonths := [ "January", "February", "March", "April", "May", "June", "July",
+                         "August", "September", "October", "November", "December"];
+          return Concatenation(String(day)," ", allMonths[month], " ", String(year));
+        end(~.Date),
+        RELEASEYEAR := ~.Date{[7..10]},
+    ),
+),
 
 ));
 

--- a/doc/guava.xml
+++ b/doc/guava.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 
-<!DOCTYPE Book SYSTEM "gapdoc.dtd">
+<!DOCTYPE Book SYSTEM "gapdoc.dtd" [
+ <#Include SYSTEM "_entities.xml">
+]>
 
 <Book Name="guava">                           <!-- REQUIRED -->
 
@@ -16,7 +18,7 @@
        &nbsp;
     </Subtitle>
 
-    <Version>Version 3.18</Version>     <!-- OPTIONAL -->
+    <Version>Version &VERSION;</Version>     <!-- OPTIONAL -->
 <Author>
 Jasper Cramwinckel
 </Author>
@@ -64,7 +66,7 @@ Joe Fields (Maintainer)
     <Email>fieldsj1@southernct.edu</Email> 
     <Homepage>http://giam.southernct.edu/</Homepage>
 </Author> 
-<Date>January, 2023</Date>    <!-- OPTIONAL -->
+<Date>&RELEASEDATE;</Date>    <!-- OPTIONAL -->
 <Copyright>     <!-- OPTIONAL -->
 <Package>GUAVA</Package>: &copyright; The GUAVA Group: 1992-2003
 Jasper Cramwinckel, Erik Roijackers,Reinald Baart, Eric Minkes,
@@ -173,7 +175,7 @@ Wayne Irons, Clifton (Clipper) Lennon, Jason McGowan, Shuhong Gao,
 Greg Gamble and Jeffrey S. Leon.
 <P/>
 For documentation on Leon's programs, 
-see the src/leon/doc subdirectory of <Package>GUAVA</Package>.
+see the <F>src/leon/doc subdirectory</F> of <Package>GUAVA</Package>.
 
 </Acknowledgements>
 </TitlePage>              <!-- end of title page --> 

--- a/makedoc.g
+++ b/makedoc.g
@@ -1,67 +1,17 @@
-###########################################################################
+##  this creates the documentation, needs: GAPDoc and AutoDoc packages, pdflatex
 ##
-#W    buildman.g               GUAVA Package            Alexander Konovalov
-##                                                      
-###########################################################################
+##  Call this with GAP from within the package directory.
 
+if fail = LoadPackage("AutoDoc", ">= 2019.04.10") then
+    Error("AutoDoc 2019.04.10 or newer is required");
+fi;
 
-ExtractMyManualExamples:=function( pkgname, main, files )
-local path, tst, i, s, name, output, ch, a;
-path:="doc";
-Print("Extracting manual examples for ", pkgname, " package ...\n" );
-tst:=ExtractExamples( path, main, files, "Chapter" );
-Print(Length(tst), " chapters detected\n");
-for i in [ 1 .. Length(tst) ] do 
-  Print( "Chapter ", i, " : \c" );
-  if Length( tst[i] ) > 0 then
-    s := String(i);
-    if Length(s)=1 then 
-      # works for <100 chapters
-      s:=Concatenation("0",s); 
-    fi;
-    name := Filename( Directory( "tst" ), 
-                Concatenation( LowercaseString(pkgname), s, ".tst" ) );
-    output := OutputTextFile( name, false ); # to empty the file first
-    SetPrintFormattingStatus( output, false ); # to avoid line breaks
-    ch := tst[i];
-    AppendTo(output, "# ", pkgname, ", chapter ",i,"\n");
-    for a in ch do
-      AppendTo(output, "\n# ",a[2], a[1]);
-    od;
-    Print("extracted ", Length(ch), " examples \n");
-  else
-    Print("no examples \n" );    
-  fi;  
-od;
-end;
-
-###########################################################################
-
-GUAVAMANUALFILES:=[ 
-"../PackageInfo.g", 
-];
-
-###########################################################################
-##
-##  GUAVABuildManual()
-##
-GUAVABuildManual:=function()
-local mypath, path, main, files, f, bookname;
-path:="doc";
-main:="guava.xml";
-bookname:="guava";
-MakeGAPDocDoc( path, main, GUAVAMANUALFILES, bookname, "/usr/lib/gap-4.12.2", "MathJax" );  
-CopyHTMLStyleFiles( path );
-GAPDocManualLab( "guava" );; 
-ExtractMyManualExamples( "guava", main, GUAVAMANUALFILES);
-end;
-
-
-###########################################################################
-
-GUAVABuildManual();
-
-###########################################################################
-##
-#E
-##
+AutoDoc(rec(
+    scaffold := rec(
+        bib := "guava_bib.xml",
+        MainPage := false,
+        TitlePage := false,
+    ),
+    extract_examples := true,
+    gapdoc := rec( main := "guava.xml" ),
+));


### PR DESCRIPTION
Use this to avoid duplicating the package version and release date in
doc/guava.xml, removing one potential source for mistakes when doing
releases.

The main advantage is that it removes the hard coded path to a GAP
executable, and also works correctly with ReleaseTools.
