### PR TITLE
desauto: initialize the comment array to a sensible value

### DIFF
--- a/src/leon/src/desauto.c
+++ b/src/leon/src/desauto.c
@@ -202,7 +202,7 @@ int main( int argc, char *argv[])
    char tempArg[8];
    enum { DESIGN_AUTO, DESIGN_ISO, MATRIX_AUTO, MATRIX_ISO, CODE_AUTO,
           CODE_ISO} computationType = DESIGN_AUTO;
-   char comment[1024];
+   char comment[1024] = "";
 
    /* Check whether the first parameters are iso, code, or matrix.
       Set the computation type. */


### PR DESCRIPTION
If left uninitialized, the comment array is passed down to client code without being even written to, which means it contains whatever happens to be on the stack whenever the frame for `main` is created. Recent changes to glibc start code have changed said content, and the new one happens to break the test suite when propagated into some temporary files that are then fed to the main leonconv binary.

That explains why using ThreadSanitizer "fixes" the test suite: presumably, the runtime initialization code happens to write in that aread of the stack and changes yet again the contents of the comment array, which happens to suit whatever expectations are in leonconv.

Fixes #98