### PR TITLE
Fix logical AND in assignGenName

### DIFF
--- a/src/leon/src/permgrp.c
+++ b/src/leon/src/permgrp.c
@@ -241,7 +241,7 @@ void assignGenName(
          let2 = tolower( oldGen->name[1]);
          if ( strlen(oldGen->name) == 1 )
             inUse[let1] = TRUE;
-         else if ( strlen(oldGen->name) == 2 && let1 == let2 & let1 >= 64 )
+         else if ( strlen(oldGen->name) == 2 && let1 == let2 && let1 >= 64 )
             inUse[let1-64] = TRUE;
       }
       for ( i = 0 ; i < 26 ; ++i )


### PR DESCRIPTION
GCC complains:
```
./src/permgrp.c:244:54: warning: suggest parentheses around comparison in operand of ‘&’ [-Wparentheses]
  244 |          else if ( strlen(oldGen->name) == 2 && let1 == let2 & let1 >= 64 )
      |                                                 ~~~~~^~~~~~~
```

But the code seems to need a logical AND there, rather than a bitwise AND.