### PR TITLE
Call strcat instead of strcmp in randobj

### DIFF
--- a/src/leon/src/randobj.c
+++ b/src/leon/src/randobj.c
@@ -110,7 +110,7 @@ int main(
    seed = 47;
    for ( i = 1 ; i < optionCountPlus1 ; ++i )
       if ( strcmp(argv[i],"-a") == 0 )
-         strcat( options.outputFileMode, "a");
+         strcpy( options.outputFileMode, "a");
       else if ( strcmp(argv[i],"-e") == 0 )
          equalSizeFlag = TRUE;
       else if ( strncmp( argv[i], "-n:", 3) == 0 )

--- a/src/leon/src/randobj.c
+++ b/src/leon/src/randobj.c
@@ -110,7 +110,7 @@ int main(
    seed = 47;
    for ( i = 1 ; i < optionCountPlus1 ; ++i )
       if ( strcmp(argv[i],"-a") == 0 )
-         strcmp( options.outputFileMode, "a");
+         strcat( options.outputFileMode, "a");
       else if ( strcmp(argv[i],"-e") == 0 )
          equalSizeFlag = TRUE;
       else if ( strncmp( argv[i], "-n:", 3) == 0 )


### PR DESCRIPTION
The `strcmp` call is a no-op, since the return value is discarded.  I believe `strcat` was intended.