### PR TITLE
Fix Codeword looping forever on an empty list

### DIFF
--- a/lib/codeword.gi
+++ b/lib/codeword.gi
@@ -155,15 +155,27 @@ StringToVec := function(s)
 end;
 
 
+## An empty list is a string, so the three methods below must not hand one
+## back to Codeword: they would be selected again, and loop forever.
+
 InstallOtherMethod(Codeword,"string,n,FFE",true,[IsString,IsInt,IsFFE],0,
 function(s,n,ffe)
+    local c;
     s:=StringToVec(s);
+    if IsEmpty(s) then
+        c := MakeCodeword(s, n, ffe);
+        TreatAsVector(c);
+        return c;
+    fi;
     return Codeword(s,n,ffe);
 end);
 
 InstallOtherMethod(Codeword,"string,n,Field",true,[IsString,IsInt,IsField],0,
 function(s,n,F)
     s := StringToVec(s);
+    if IsEmpty(s) then
+        return Codeword(s, n, One(F));
+    fi;
     return Codeword(s, n, F);
 end);
 
@@ -181,6 +193,9 @@ InstallOtherMethod(Codeword, "string,n", true, [IsString, IsInt], 0,
 function(s, n)
     local F;
     s := StringToVec(s);
+    if IsEmpty(s) then
+        return Codeword(s, n, Z(2));    # as the method for lists does
+    fi;
     F := SelectField(s);
     return Codeword(s, n, F);
 end);

--- a/tst/bugfix.tst
+++ b/tst/bugfix.tst
@@ -22,6 +22,26 @@ gap> Display(G1);
  . . . . . . . . . . . 1 . 1 . 1 1 1 . . . 1 1
 
 ##
+## an empty list is a string, so Codeword([], ...) used to be handed back
+## to the very method that produced it, looping forever.  Encoding the zero
+## information word into a cyclic code goes through exactly that call.
+##
+gap> Codeword([], 4, Z(5)^0);
+[ 0 0 0 0 ]
+gap> Codeword([], 4, GF(5));
+[ 0 0 0 0 ]
+gap> Codeword([], 4);
+[ 0 0 0 0 ]
+gap> C := ReedSolomonCode(4,3);;
+gap> c := [0*Z(5),0*Z(5)]*C;;
+gap> WordLength(c) = WordLength(C) and c in C;
+true
+gap> Codeword("1010", 4, GF(2));   # strings still work
+[ 1 0 1 0 ]
+gap> Codeword("123", 5, GF(4));
+[ 1 a a^2 0 0 ]
+
+##
 ## BCHDecoder assumed a narrow sense code and bailed out to Decode for any
 ## other b, which has no method for the polynomial it was handed (and would
 ## have dispatched straight back into BCHDecoder had it had one).


### PR DESCRIPTION
> [!NOTE]
> Stacked on #130, at the end of the #129 → #131 → #130 chain. Unrelated to those three — it is here only so the four form one stack. The diff is just this change.

GAP considers the empty list a string, so `Codeword([], n, F)` selected the method for strings, whose `StringToVec` handed back an empty list, which selected the same method again.

This is reachable from ordinary use: encoding the zero information word into a cyclic code multiplies the zero polynomial by the generator, and the resulting zero polynomial has an empty coefficient list.

    C := ReedSolomonCode(4,3);
    [0*Z(5),0*Z(5)]*C;      # Error, recursion depth trap (5000)

Handle the empty list in the three methods for strings that would otherwise dispatch back into themselves.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
