### PR TITLE
Fix the generalized Reed-Solomon interpolation decoder

### DIFF
--- a/lib/decoders.gi
+++ b/lib/decoders.gi
@@ -148,7 +148,9 @@ function(C, v)
     if HasSpecialDecoder(C) then
         c0:=SpecialDecoder(C)(C, c);
         if Size(c0) = Dimension(C) then
-            return Codeword(c0*C);
+            # re-encode via the generator matrix, the encoding that
+            # InformationWord (and hence every special decoder) inverts
+            return Codeword(VectorCodeword(c0)*GeneratorMat(C), C);
         fi;
         if Size(c0) = Size(c) then
             return Codeword(c0);
@@ -639,7 +641,7 @@ end;
 InstallMethod(GeneralizedReedSolomonDecoder,"method for code, codeword", true,
     [IsCode, IsCodeword], 0,
 function(C,vec)
-local v,R,k,P,z,F,f,s,t,L,n,Qpolys,vars,x,c,y;
+local v,R,k,P,F,f,qr,s,t,L,n,Qpolys,vars,x,c;
 
  v:=VectorCodeword(vec);
  R:=C!.ring;
@@ -648,14 +650,22 @@ local v,R,k,P,z,F,f,s,t,L,n,Qpolys,vars,x,c,y;
  F:=CoefficientsRing(R);
  vars:=IndeterminatesOfPolynomialRing(R);
  x:=vars[1];
-#y:=vars[2];
  n:=Length(v);
  t:=Int((n-k)/2);
  L:=[n-1-t,n-t-k];
  Qpolys:=GRSErrorLocatorPolynomials(v,P,L,R);
- f:=-Qpolys[2]/Qpolys[1];
+ if Qpolys=[] or IsZero(Qpolys[2]) then
+   Error("not decodable");
+ fi;
+ # Q(x,y) = Qpolys[1](x) + Qpolys[2](x)*y vanishes at every (P[i],v[i]), so the
+ # message polynomial f is the one with Qpolys[1] + Qpolys[2]*f = 0.
+ qr:=QuotientRemainder(R,Qpolys[1],Qpolys[2]);
+ if not IsZero(qr[2]) or Degree(qr[1]) >= k then
+   Error("not decodable");
+ fi;
+ f:=-qr[1];
  c:=List(P,s->Value(f,[x],[s]));
- return Codeword(c,n,F);
+ return InformationWord(C, Codeword(c,n,F));
 end);
 
 

--- a/tst/decoding.tst
+++ b/tst/decoding.tst
@@ -252,3 +252,24 @@ true
 gap> w := Decodeword(C,c);;
 gap> (c=w);
 true
+
+##
+## https://github.com/gap-packages/guava/issues/12
+## the GRS interpolation decoder mixed up the two halves of the
+## interpolating polynomial and so returned an unrelated word
+##
+gap> R := PolynomialRing(GF(11),1);;
+gap> P := List([1,3,4,5,7],i->Z(11)^i);;
+gap> C := GeneralizedReedSolomonCode(P,3,R);
+a linear [5,3,1..3]2  generalized Reed-Solomon code over GF(11)
+gap> c := Codeword([5,4,5,4,2],GF(11));;
+gap> c in C;
+true
+gap> r := Codeword([5,4,5,5,2],GF(11));;
+gap> Decodeword(C,r) = c;
+true
+gap> Decode(C,r) = InformationWord(C,c);
+true
+gap> v := Codeword([5,2,6,10,9],GF(11));;
+gap> Decodeword(C,v) = GeneralizedReedSolomonDecoderGao(C,v);
+true


### PR DESCRIPTION
The interpolation step produces `Q(x,y) = Q0(x) + Q1(x)*y` vanishing at every `(P[i],v[i])`, so the message polynomial is `f = -Q0/Q1`. `GeneralizedReedSolomonDecoder` computed `-Q1/Q0` instead and returned the evaluations of that unrelated rational function.

It also now returns an information word. `Decode` passes a special decoder's result through verbatim and is documented to return an information word, so returning a codeword made `Decode` fail outright (the reported symptom).  That in turn exposed `Decodeword` re-encoding via `c0*C`, which for a cyclic code multiplies by the generator polynomial while InformationWord inverts the generator matrix; for a GRS code that happens to be cyclic the two disagree.

That second part is the last outstanding item of #126: `GeneralizedReedSolomonDecoder` was the only special decoder still returning a codeword rather than an information word. Checking both halves of the contract (`Decode` returns the information vector, `Decodeword` the nearest codeword) on words carrying errors, for every decoder that is actually installed via `SetSpecialDecoder`:

| special decoder | before | after |
| --- | --- | --- |
| `HammingDecoder` (GF(2), GF(3)) | ok | ok |
| `BCHDecoder` (RS/GF(11), BCH/GF(2), BCH/GF(3)) | ok | ok |
| `CyclicDecoder` (binary cyclic [7,4,3]) | ok | ok |
| `GeneralizedReedSolomonDecoder` (GF(11), GF(5)) | dies, "Denominator evaluates as zero" | ok |

Hamming, BCH and cyclic were already put right by fc0434c, 6547003 and 94a9c9d.

Fixes #12
Fixes #126

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
