### PR TITLE
Decode BCH codes that are not narrow sense

### DIFF
--- a/lib/codeword.gi
+++ b/lib/codeword.gi
@@ -155,15 +155,27 @@ StringToVec := function(s)
 end;
 
 
+## An empty list is a string, so the three methods below must not hand one
+## back to Codeword: they would be selected again, and loop forever.
+
 InstallOtherMethod(Codeword,"string,n,FFE",true,[IsString,IsInt,IsFFE],0,
 function(s,n,ffe)
+    local c;
     s:=StringToVec(s);
+    if IsEmpty(s) then
+        c := MakeCodeword(s, n, ffe);
+        TreatAsVector(c);
+        return c;
+    fi;
     return Codeword(s,n,ffe);
 end);
 
 InstallOtherMethod(Codeword,"string,n,Field",true,[IsString,IsInt,IsField],0,
 function(s,n,F)
     s := StringToVec(s);
+    if IsEmpty(s) then
+        return Codeword(s, n, One(F));
+    fi;
     return Codeword(s, n, F);
 end);
 
@@ -181,6 +193,9 @@ InstallOtherMethod(Codeword, "string,n", true, [IsString, IsInt], 0,
 function(s, n)
     local F;
     s := StringToVec(s);
+    if IsEmpty(s) then
+        return Codeword(s, n, Z(2));    # as the method for lists does
+    fi;
     F := SelectField(s);
     return Codeword(s, n, F);
 end);

--- a/lib/decoders.gi
+++ b/lib/decoders.gi
@@ -309,25 +309,29 @@ end);
 InstallMethod(BCHDecoder, "method for code, codeword", true,
     [IsCode, IsCodeword], 0,
 function (C, r)
-    local F, q, n, m, ExtF, x, a, t, ri_1, ri, rnew, si_1, si, snew,
-          ti_1, ti, qi, sigma, i, cc, cl, mp, ErrorLocator, zero,
+    local F, q, n, m, ExtF, x, a, b, j, delta, t, ri_1, ri, rnew, si_1, si,
+          snew, ti_1, ti, qi, sigma, i, cc, cl, mp, ErrorLocator, zero,
           Syndromes, null, pol, ExtSize, ErrorEvaluator, ret;
     F := LeftActingDomain(C);
     q := Size(F);
     n := WordLength(C);
     m := OrderMod(q,n);
-    t := QuoInt(DesignedDistance(C) - 1, 2);
+    delta := DesignedDistance(C);
+    t := QuoInt(delta - 1, 2);
     ExtF := GF(q^m);
     x := Indeterminate(ExtF);
     a := PrimitiveUnityRoot(q,n);
     zero := Zero(ExtF);
     r := PolyCodeword(Codeword(r, n, F));
-    if Value(GeneratorPol(C), a) <> zero then
-        return Decode(C, r);  ##LR - inf loop !!!
+    # The code has delta-1 consecutive roots a^b,...,a^(b+delta-2).  b is 1 for
+    # a narrow sense code, but BCHCode also builds codes with other b.
+    b := First([0..n-1], i->ForAll([i..i+delta-2],
+                                   j->Value(GeneratorPol(C), a^j) = zero));
+    if b = fail then
+        Error("code has no ", delta-1, " consecutive roots");
     fi;
     # Calculate syndrome: this simple line is faster than using minimal pols.
-    Syndromes :=  List([1..2*QuoInt(DesignedDistance(C) - 1,2)],
-                       i->Value(r, a^i));
+    Syndromes := List([0..2*t-1], i->Value(r, a^(b+i)));
     if Maximum(Syndromes) = Zero(F) then # no errors
         ret := Codeword(r mod (x^n-1), C);
         TreatAsVector(ret);
@@ -374,8 +378,10 @@ function (C, r)
         pol := Derivative(sigma);
         ErrorEvaluator := List(ErrorLocator,i->
                               Value(rnew,a^-i)/Value(pol, a^-i));
+        # Forney: the error at position i is -a^(i*(1-b))*ErrorEvaluator
         pol := Sum(List([1..Length(ErrorLocator)], i->
-                       -ErrorEvaluator[i]*x^ErrorLocator[i]));
+                       -a^(ErrorLocator[i]*(1-b))*ErrorEvaluator[i]
+                        *x^ErrorLocator[i]));
     fi;
     ret := Codeword((r - pol) mod (x^n-1), C);
     TreatAsVector(ret);

--- a/tst/bugfix.tst
+++ b/tst/bugfix.tst
@@ -22,6 +22,26 @@ gap> Display(G1);
  . . . . . . . . . . . 1 . 1 . 1 1 1 . . . 1 1
 
 ##
+## an empty list is a string, so Codeword([], ...) used to be handed back
+## to the very method that produced it, looping forever.  Encoding the zero
+## information word into a cyclic code goes through exactly that call.
+##
+gap> Codeword([], 4, Z(5)^0);
+[ 0 0 0 0 ]
+gap> Codeword([], 4, GF(5));
+[ 0 0 0 0 ]
+gap> Codeword([], 4);
+[ 0 0 0 0 ]
+gap> C := ReedSolomonCode(4,3);;
+gap> c := [0*Z(5),0*Z(5)]*C;;
+gap> WordLength(c) = WordLength(C) and c in C;
+true
+gap> Codeword("1010", 4, GF(2));   # strings still work
+[ 1 0 1 0 ]
+gap> Codeword("123", 5, GF(4));
+[ 1 a a^2 0 0 ]
+
+##
 ## BCHDecoder assumed a narrow sense code and bailed out to Decode for any
 ## other b, which has no method for the polynomial it was handed (and would
 ## have dispatched straight back into BCHDecoder had it had one).

--- a/tst/bugfix.tst
+++ b/tst/bugfix.tst
@@ -20,3 +20,27 @@ gap> Display(G1);
  . . . . . . . . . 1 . . . . 1 . 1 1 . 1 1 1 .
  . . . . . . . . . . 1 . 1 . 1 1 1 . . . 1 1 1
  . . . . . . . . . . . 1 . 1 . 1 1 1 . . . 1 1
+
+##
+## BCHDecoder assumed a narrow sense code and bailed out to Decode for any
+## other b, which has no method for the polynomial it was handed (and would
+## have dispatched straight back into BCHDecoder had it had one).
+##
+gap> C := BCHCode(8,4,3,3);
+a cyclic [8,5,3]2..3 BCH code, delta=3, b=4 over GF(3)
+gap> c := Codeword([1,0,0,2,0,1,1,2], C);;
+gap> c in C;
+true
+gap> r := Codeword([1,2,0,2,0,1,1,2], C);;
+gap> Decodeword(C, r) = c;
+true
+gap> Decode(C, r) = InformationWord(C, c);
+true
+gap> C := BCHCode(13,4,5,3);
+a cyclic [13,4,6..7]5..8 BCH code, delta=6, b=4 over GF(3)
+gap> c := Codeword([1,1,2,2,0,2,2,2,1,0,1,0,2], C);;
+gap> c in C;
+true
+gap> r := Codeword([1,0,2,2,0,2,2,2,0,0,1,0,2], C);;   # two errors
+gap> Decodeword(C, r) = c;
+true


### PR DESCRIPTION
> [!NOTE]
> Stacked on #131, which is stacked on #129. The diff here is just this change.

`BCHDecoder` ran the Sugiyama algorithm as if the code's roots always started at `a^1`.  For any other `b` it bailed out to `Decode`, passing the polynomial it had built rather than a codeword, so decoding failed with "no method found"; had the argument been right, `Decode` would have dispatched straight back into `BCHDecoder`. `BCHCode` readily produces such codes, e.g. `BCHCode(8,4,3,3)`.

Read `b` off the generator polynomial as the start of its run of `delta-1` consecutive roots, take the syndromes from `a^b` onwards, and apply the `X^(1-b)` factor Forney's formula carries for `a` general `b`.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
