### PR TITLE
Detect undecodable words in the BCH decoder

### DIFF
--- a/doc/guava.xml
+++ b/doc/guava.xml
@@ -3763,11 +3763,7 @@ codeword is decoded to an <E>information codeword</E> <M>m</M>
 (and not an element of <A>C</A>).
 If the code record has a field `specialDecoder',
 this special algorithm is used to decode
-the vector.  Hamming codes,
-<!--
-BCH codes, - removed due to an unfixed bug
--->
-cyclic codes,
+the vector.  Hamming codes, BCH codes, cyclic codes,
 and generalized Reed-Solomon have such a special algorithm.
 (The algorithm used for BCH codes is the
 Sugiyama algorithm described, for example, in
@@ -3841,13 +3837,14 @@ codeword or a list of codewords.
 If the code record has a field `specialDecoder',
 this special algorithm is used to decode
 the vector.  Hamming codes, generalized Reed-Solomon codes,
-and BCH codes have such a special algorithm.
+BCH codes and cyclic codes have such a special algorithm.
 (The algorithm used for BCH codes is the
 Sugiyama algorithm described, for example, in
 section 5.4.3 of <Cite Key="HP03"/>. The algorithm used for
 generalized Reed-Solomon codes is the ``interpolation
 algorithm'' described for example in chapter 5 of
-<Cite Key="JH04"/>.)
+<Cite Key="JH04"/>. For cyclic codes, the error-trapping
+algorithm is used.)
 If <A>C</A> is linear and no special decoder
 field has been set then syndrome decoding is used.
 Otherwise, when <A>C</A> is non-linear, the nearest neighbor algorithm has

--- a/lib/decoders.gi
+++ b/lib/decoders.gi
@@ -311,7 +311,7 @@ InstallMethod(BCHDecoder, "method for code, codeword", true,
 function (C, r)
     local F, q, n, m, ExtF, x, a, t, ri_1, ri, rnew, si_1, si, snew,
           ti_1, ti, qi, sigma, i, cc, cl, mp, ErrorLocator, zero,
-          Syndromes, null, pol, ExtSize, ErrorEvaluator, Fp, ret;
+          Syndromes, null, pol, ExtSize, ErrorEvaluator, ret;
     F := LeftActingDomain(C);
     q := Size(F);
     n := WordLength(C);
@@ -361,27 +361,28 @@ function (C, r)
         null := null * a;
     od;
     # And decode:
-    if Length(ErrorLocator) = 0 then
+    # Unless sigma splits into distinct linear factors over the n-th roots of
+    # unity, more than t errors occurred; carrying on would divide by
+    # sigma'(a^-i) = 0 below.
+    if Length(ErrorLocator) = 0 or Length(ErrorLocator) <> Degree(sigma) then
         Error("not decodable");
     fi;
     x := Indeterminate(F);
     if q = 2 then # error locator is not necessary
         pol := Sum(List(ErrorLocator, i->x^i));
-        ret := Codeword((r - pol) mod (x^n-1), C);
-        TreatAsVector(ret);
-        return InformationWord(C,ret);
     else
         pol := Derivative(sigma);
-        Fp := One(F)*(x^n-1);
-        #Print(ErrorLocator, "\n");
         ErrorEvaluator := List(ErrorLocator,i->
                               Value(rnew,a^-i)/Value(pol, a^-i));
         pol := Sum(List([1..Length(ErrorLocator)], i->
                        -ErrorEvaluator[i]*x^ErrorLocator[i]));
-        ret := Codeword((r - pol) mod (x^n-1) , C);
-        TreatAsVector(ret);
-        return InformationWord(C,ret);
     fi;
+    ret := Codeword((r - pol) mod (x^n-1), C);
+    TreatAsVector(ret);
+    if not ret in C then    # again: more than t errors
+        Error("not decodable");
+    fi;
+    return InformationWord(C,ret);
 end);
 
 #############################################################################

--- a/tst/decoding.tst
+++ b/tst/decoding.tst
@@ -273,3 +273,35 @@ true
 gap> v := Codeword([5,2,6,10,9],GF(11));;
 gap> Decodeword(C,v) = GeneralizedReedSolomonDecoderGao(C,v);
 true
+
+##
+## https://github.com/gap-packages/guava/issues/41
+## the BCH decoder crashed, or silently returned a non-codeword,
+## on words carrying more than (d-1)/2 errors
+##
+gap> C := ReedSolomonCode(10,5);
+a cyclic [10,6,5]3..4 Reed-Solomon code over GF(11)
+gap> Decodeword(C, Codeword([7,10,3,2,4,9,5,7,5,9],C));
+Error, not decodable
+gap> Decodeword(C, Codeword([10,7,3,1,8,1,8,7,4,8],C));
+Error, not decodable
+gap> Decodeword(C, Codeword([4,0,0,6,5,0,0,0,0,0],C));
+Error, not decodable
+gap> Decodeword(C, Codeword([5,1,1,7,2,6,4,6,1,5],C));
+Error, not decodable
+gap> Decodeword(C, Codeword([3,7,5,5,1,10,3,9,2,8],C));
+Error, not decodable
+gap> C := ReedSolomonCode(10,4);
+a cyclic [10,7,4]2..3 Reed-Solomon code over GF(11)
+gap> Decodeword(C, Codeword([2,7,8,3,7,10,3,4,3,4],C));
+Error, not decodable
+
+## words within (d-1)/2 of the code must still decode
+gap> C := ReedSolomonCode(10,5);;
+gap> c := Codeword([1,2,3,4,5,6],GF(11))*C;;
+gap> r := ShallowCopy(VectorCodeword(c));;
+gap> r[3] := r[3]+Z(11);; r[7] := r[7]+Z(11)^3;;
+gap> Decodeword(C, Codeword(r,C)) = c;
+true
+gap> Decode(C, Codeword(r,C)) = InformationWord(C,c);
+true


### PR DESCRIPTION
> [!NOTE]
> Stacked on #129 — that is the base branch, so the diff here is just this change. Merge #129 first and this retargets to master on its own.

Nothing checked that the error locator polynomial sigma produced by the Euclidean algorithm was usable.  With more than `t` errors `sigma` picks up repeated roots, or roots outside the n-th roots of unity, and Forney's formula then divides by `sigma'(a^-i) = 0`; where it happened not to, the decoder returned a word that was not in the code at all.

Reject a sigma whose distinct roots among the n-th roots of unity do not account for its degree, and verify the corrected word lies in the code.  Both raise the "not decodable" error the function already used for this case.

The second commit fixes the two lists of codes that have a special decoder. `Decode` had BCH codes commented out of its list, "removed due to an unfixed bug"; `Decodeword` was missing cyclic codes from its own. Only `doc/guava.xml` is tracked, so no regenerated files are involved.

Fixes #41

