### PR TITLE
Stop truncating code lengths to 16 bits in minimum-weight

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -47,6 +47,8 @@ jobs:
       - uses: gap-actions/run-pkg-tests@v4
         with:
           mode: onlyneeded
+      - name: Exercise minimum-weight directly
+        run: make check-programs
       # gcov is only set up to work on the Linux jobs
       - uses: gap-actions/process-coverage@v3
         if: ${{ runner.os == 'Linux' }}

--- a/Makefile.in
+++ b/Makefile.in
@@ -93,6 +93,23 @@ check test:
 run:
 	$(GAP) $(GAP_ARGS) -c 'LoadPackage("guava");'
 
+# exercises minimum-weight on inputs the GAP code never produces: a code
+# longer than the 16-bit types it used to count with, and malformed files
+check-programs: all
+	@set -e; tmp=`mktemp -d`; trap "rm -rf $$tmp" EXIT; \
+	awk 'BEGIN { n = 65536; printf "3 %d 2\n", n+3; \
+	             for (r = 1; r <= 3; r++) { \
+	                 for (i = 1; i <= n; i++) printf "1 "; \
+	                 for (i = 1; i <= 3; i++) printf "%d ", (i == r); \
+	                 printf "\n" } }' > $$tmp/long; \
+	echo "== a [65539,3] code, minimum weight 2"; \
+	$(BINDIR)/minimum-weight $$tmp/long | grep -q '^Minimum weight: 2$$'; \
+	echo "== malformed input is rejected, not crashed on"; \
+	printf 'garbage\n'   > $$tmp/bad;   ! $(BINDIR)/minimum-weight $$tmp/bad;   \
+	printf '0 10 2\n'    > $$tmp/zero;  ! $(BINDIR)/minimum-weight $$tmp/zero;  \
+	printf '2 5 2\n1 0 1\n' > $$tmp/trunc; ! $(BINDIR)/minimum-weight $$tmp/trunc; \
+	echo "== ok"
+
 clean:
 	rm -rf $(OBJDIR)
 
@@ -103,4 +120,4 @@ distclean: clean
 Makefile: configure Makefile.in $(GAPPATH)/sysinfo.gap
 	./configure $(GAPPATH)
 
-.PHONY: all check test clean distclean doc html run
+.PHONY: all check check-programs test clean distclean doc html run

--- a/src/ctjhai/minimum-weight-gf2.c
+++ b/src/ctjhai/minimum-weight-gf2.c
@@ -73,7 +73,7 @@ int mindist_gf2(MATRIX G, mod_t m_mod, int lower_bound) {
 	 */
 	j = (G.cols - G.rows) + 1;	/* maximum possible number of matrices */
 	packedG.mat = (packed_t ***)malloc(j * sizeof(packed_t **));
-	packedG.rank= (unsigned short *)malloc(j * sizeof(unsigned short));
+	packedG.rank= (unsigned int *)malloc(j * sizeof(unsigned int));
 	packedG.dimension = G.rows;
 	packedG.block_length = G.cols;
 	packedG.nMatrices = packedG.nFullRankMatrices = 0;
@@ -190,7 +190,7 @@ int cyclic_mindist_gf2(MATRIX G, mod_t m_mod, int lower_bound) {
 	 */
 	j = 1;	/* only one generator matrix */
 	packedG.mat = (packed_t ***)malloc(j * sizeof(packed_t **));
-	packedG.rank= (unsigned short *)malloc(j * sizeof(unsigned short));
+	packedG.rank= (unsigned int *)malloc(j * sizeof(unsigned int));
 	packedG.dimension = G.rows;
 	packedG.block_length = G.cols;
 	packedG.nMatrices = j; 
@@ -317,10 +317,10 @@ void __mindist_gf2(PACKED_MATRIX_GF2 *G, INFO *info) {
 		} while (l);\
 	}
 	double steps;
-	short m, iw, top, In, Out, nMat;
-	register short i, j, l, w;
+	int m, iw, top, In, Out, nMat;
+	register int i, j, l, w;
 	register packed_t **c;
-	short *v, *s;
+	int *v, *s;
 
 	w = top = 0;
 	nMat = info->matrices_req;
@@ -336,8 +336,8 @@ void __mindist_gf2(PACKED_MATRIX_GF2 *G, INFO *info) {
 		steps = 0;
 		
 		m = iw - 1;
-		v = (short *) malloc((iw+2)*sizeof(short));
-		s = (short *) malloc((iw+2)*sizeof(short));
+		v = (int *) malloc((iw+2)* sizeof(int));
+		s = (int *) malloc((iw+2)* sizeof(int));
 		
 		if ( !(iw & 1) ) {
 			v[iw + 1] = G->dimension; v[iw] = iw - 1;
@@ -453,10 +453,10 @@ void __cyclic_mindist_gf2(PACKED_MATRIX_GF2 *G, INFO *info) {
 		}\
 	}
 	double steps;
-	short m, iw, top, In, Out;
-	register short i, j, w;
+	int m, iw, top, In, Out;
+	register int i, j, w;
 	register packed_t *c;
-	short *v, *s;
+	int *v, *s;
 
 	w = top = 0;
 	c = (packed_t *)malloc(G->nBlocks * sizeof(packed_t)); 
@@ -467,8 +467,8 @@ void __cyclic_mindist_gf2(PACKED_MATRIX_GF2 *G, INFO *info) {
 		steps = 0;
 		
 		m = iw - 1;
-		v = (short *) malloc((iw+2)*sizeof(short));
-		s = (short *) malloc((iw+2)*sizeof(short));
+		v = (int *) malloc((iw+2)* sizeof(int));
+		s = (int *) malloc((iw+2)* sizeof(int));
 		
 		if ( !(iw & 1) ) {
 			v[iw + 1] = G->dimension; v[iw] = iw - 1;
@@ -553,7 +553,7 @@ lower_bound_met:
 /* current progress of enumeration.                                 */
 void update_info_gf2(PACKED_MATRIX_GF2 *G, INFO *info) {
 	bool end;
-	short i, j, l, d, w;
+	int i, j, l, d, w;
 	
 	/* Estimate the number of matrices required to complete enumeration */
 	info->matrices_req = 0;
@@ -633,7 +633,7 @@ void update_info_gf2(PACKED_MATRIX_GF2 *G, INFO *info) {
 /* Update INFO structure, which contains various information on the */
 /* current progress of enumeration.                                 */
 void cyclic_update_info_gf2(PACKED_MATRIX_GF2 *G, INFO *info) {
-	short i, d, w;
+	int i, d, w;
 	
 	/* Estimate the minimum distance lower bound after current enumeration */
 	info->lower_bound = (info->info_weight_completed + 1) * G->nFullRankMatrices;

--- a/src/ctjhai/minimum-weight-gf2.h
+++ b/src/ctjhai/minimum-weight-gf2.h
@@ -19,10 +19,10 @@
 
 /*------------- Data structure specified for GF(2) --------------*/
 typedef struct {
-	unsigned short dimension, block_length;
-	unsigned short nBlocks;
-	unsigned short nMatrices, nFullRankMatrices;
-	unsigned short *rank;
+	unsigned int dimension, block_length;
+	unsigned int nBlocks;
+	unsigned int nMatrices, nFullRankMatrices;
+	unsigned int *rank;
 	packed_t ***mat;
 } PACKED_MATRIX_GF2;
 

--- a/src/ctjhai/minimum-weight-gf3.c
+++ b/src/ctjhai/minimum-weight-gf3.c
@@ -94,7 +94,7 @@ int mindist_gf3(MATRIX G, mod_t m_mod, int lower_bound) {
 	 */
 	j = (G.cols - G.rows) + 1;	/* maximum possible number of matrices */
 	packedG.mat = (GF3_VEC ***)malloc(j * sizeof(GF3_VEC **));
-	packedG.rank= (unsigned short *)malloc(j * sizeof(unsigned short));
+	packedG.rank= (unsigned int *)malloc(j * sizeof(unsigned int));
 	packedG.dimension = G.rows;
 	packedG.block_length = G.cols;
 	packedG.nMatrices = packedG.nFullRankMatrices = 0;
@@ -207,7 +207,7 @@ int cyclic_mindist_gf3(MATRIX G, mod_t m_mod, int lower_bound) {
 	 */
 	j = 1;	/* only one generator matrix */
 	packedG.mat = (GF3_VEC ***)malloc(j * sizeof(GF3_VEC **));
-	packedG.rank= (unsigned short *)malloc(j * sizeof(unsigned short));
+	packedG.rank= (unsigned int *)malloc(j * sizeof(unsigned int));
 	packedG.dimension = G.rows;
 	packedG.block_length = G.cols;
 	packedG.nMatrices = j; 
@@ -292,7 +292,7 @@ completed:
 /* Minimum weight enumeration function for information weight >= 2 */
 void __mindist_gf3(PACKED_MATRIX_GF3 *G, INFO *info) {
 #define EVALUATE_MINIMUM_WEIGHT_GF3	{\
-		memset(a, 0, m * sizeof(short));\
+		memset(a, 0, m * sizeof(*a));\
 		f[m] = m; j = m; do { --j; f[j] = j; } while (j);\
 		while (1) {\
 			l=info->matrices_req; do { --l;\
@@ -321,10 +321,10 @@ void __mindist_gf3(PACKED_MATRIX_GF3 *G, INFO *info) {
 		}\
 	}
 	double steps;
-	short m, iw, top, nMat;
-	register short i, j, l, w;
+	int m, iw, top, nMat;
+	register int i, j, l, w;
 	register GF3_VEC **c;
-	short *v, *s, *a, *f;
+	int *v, *s, *a, *f;
 	packed_t t1, t2;
 	
 	/* G2 contains a set of generator matrices of G->nFullRankMatrices disjoint */
@@ -359,10 +359,10 @@ void __mindist_gf3(PACKED_MATRIX_GF3 *G, INFO *info) {
 		steps = 0;
 		
 		m = iw - 1;
-		v = (short *) malloc((iw+2)*sizeof(short));
-		s = (short *) malloc((iw+2)*sizeof(short));
-		a = (short *) malloc(iw *sizeof(short));
-		f = (short *) malloc((iw+1)*sizeof(short));
+		v = (int *) malloc((iw+2)* sizeof(int));
+		s = (int *) malloc((iw+2)* sizeof(int));
+		a = (int *) malloc(iw * sizeof(int));
+		f = (int *) malloc((iw+1)* sizeof(int));
 		
 		if ( !(iw & 1) ) {
 			v[iw + 1] = G->dimension; v[iw] = iw - 1;
@@ -449,7 +449,7 @@ lower_bound_met:
 /* Cyclic code: minimum weight enumeration function for information weight >= 2 */
 void __cyclic_mindist_gf3(PACKED_MATRIX_GF3 *G, INFO *info) {
 #define EVALUATE_CYCLIC_MINIMUM_WEIGHT_GF3	{\
-		memset(a, 0, m * sizeof(short));\
+		memset(a, 0, m * sizeof(*a));\
 		f[m] = m; j = m; do { --j; f[j] = j; } while (j);\
 		while (1) {\
 			steps++;\
@@ -474,11 +474,11 @@ void __cyclic_mindist_gf3(PACKED_MATRIX_GF3 *G, INFO *info) {
 		}\
 	}
 	double steps;
-	short m, iw, top;
-	register short i, j, l, w;
+	int m, iw, top;
+	register int i, j, l, w;
 	register GF3_VEC *c;
 	packed_t t1, t2;
-	short *v, *s, *a, *f;
+	int *v, *s, *a, *f;
 
 	/* G2 contains a set of generator matrices of G->nFullRankMatrices disjoint */
 	/* information sets. For each information set, G2 contains (q-1) matrices,  */
@@ -505,10 +505,10 @@ void __cyclic_mindist_gf3(PACKED_MATRIX_GF3 *G, INFO *info) {
 		steps = 0;
 		
 		m = iw - 1;
-		v = (short *) malloc((iw+2)*sizeof(short));
-		s = (short *) malloc((iw+2)*sizeof(short));
-		a = (short *) malloc(iw *sizeof(short));
-		f = (short *) malloc((iw+1)*sizeof(short));
+		v = (int *) malloc((iw+2)* sizeof(int));
+		s = (int *) malloc((iw+2)* sizeof(int));
+		a = (int *) malloc(iw * sizeof(int));
+		f = (int *) malloc((iw+1)* sizeof(int));
 		
 		if ( !(iw & 1) ) {
 			v[iw + 1] = G->dimension; v[iw] = iw - 1;
@@ -590,7 +590,7 @@ lower_bound_met:
 /* current progress of enumeration.                                 */
 void update_info_gf3(PACKED_MATRIX_GF3 *G, INFO *info) {
 	bool end;
-	short i, j, l, d, w;
+	int i, j, l, d, w;
 	
 	/* Estimate the number of matrices required to complete enumeration */
 	info->matrices_req = 0;
@@ -661,7 +661,7 @@ void update_info_gf3(PACKED_MATRIX_GF3 *G, INFO *info) {
 /* Update INFO structure, which contains various information on the */
 /* current progress of enumeration.                                 */
 void cyclic_update_info_gf3(PACKED_MATRIX_GF3 *G, INFO *info) {
-	short i, d, w;
+	int i, d, w;
 	
 	/* Estimate the minimum distance lower bound after current enumeration */
 	info->lower_bound = (info->info_weight_completed + 1) * G->nFullRankMatrices;
@@ -694,13 +694,13 @@ void init_gf3(GF3 *gf) {
 	int i;
 	
 	gf->sub = (short **)malloc(3 * sizeof(short *));
-	for (i=0; i<3; i++) gf->sub[i] = (short *)malloc(3*sizeof(short));
+	for (i=0; i<3; i++) gf->sub[i] = (short *)malloc(3 * sizeof(short));
 	gf->sub[0][0] = 0; gf->sub[0][1] = 2; gf->sub[0][2] = 1;
 	gf->sub[1][0] = 1; gf->sub[1][1] = 0; gf->sub[1][2] = 2;
 	gf->sub[2][0] = 2; gf->sub[2][1] = 1; gf->sub[2][2] = 0;
 	
-	gf->div = (short **)malloc(3 * sizeof(short int *));
-	for (i=0; i<3; i++) gf->div[i] = (short *)malloc(3*sizeof(short));
+	gf->div = (short **)malloc(3 * sizeof(short *));
+	for (i=0; i<3; i++) gf->div[i] = (short *)malloc(3 * sizeof(short));
 	gf->div[0][0] = 3; gf->div[0][1] = 0; gf->div[0][2] = 0;
 	gf->div[1][0] = 3; gf->div[1][1] = 1; gf->div[1][2] = 2;
 	gf->div[2][0] = 3; gf->div[2][1] = 2; gf->div[2][2] = 1;

--- a/src/ctjhai/minimum-weight-gf3.h
+++ b/src/ctjhai/minimum-weight-gf3.h
@@ -53,10 +53,10 @@ typedef struct {
 } GF3_VEC;
 
 typedef struct {
-	unsigned short dimension, block_length;
-	unsigned short nBlocks;
-	unsigned short nMatrices, nFullRankMatrices;
-	unsigned short *rank;
+	unsigned int dimension, block_length;
+	unsigned int nBlocks;
+	unsigned int nMatrices, nFullRankMatrices;
+	unsigned int *rank;
 	GF3_VEC  ***mat;
 } PACKED_MATRIX_GF3;
 

--- a/src/ctjhai/minimum-weight.c
+++ b/src/ctjhai/minimum-weight.c
@@ -28,6 +28,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdint.h>
 #include <string.h>
 #include <getopt.h>
 #include "minimum-weight-gf2.h"
@@ -92,7 +93,8 @@ int main(int argc, char *argv[]) {
 	init_popcount();
 	
 	/* Read generator matrix from file */
-	generator_matrix(argv[optind], &G);
+	if (generator_matrix(argv[optind], &G) < 0)
+		return -1;
 
 	if (cyclic_code)
 		dmin = cyclic_mindist(G, m_mod, lower_bound);
@@ -134,9 +136,24 @@ void print_usage(FILE *stream, int exitcode, char *str) {
 	exit(exitcode);
 }
 
+/* Allocate n objects of size sz, or report why not and return NULL.
+   n * sz is computed in size_t, and rejected if it would wrap. */
+static void *alloc_array(size_t n, size_t sz, const char *what) {
+	void *p;
+
+	if (n > SIZE_MAX / sz) {
+		fprintf(stderr, "Error: %s too large to allocate\n", what);
+		return NULL;
+	}
+	p = malloc(n * sz);
+	if (!p)
+		fprintf(stderr, "Error: out of memory allocating %s\n", what);
+	return p;
+}
+
 /* Read generator matrix from file */
 int generator_matrix(char *fname, MATRIX *M) {
-	int i, j;
+	unsigned int i, j;
 	FILE *fptr;
 
 	fptr = fopen(fname, "r");
@@ -144,25 +161,44 @@ int generator_matrix(char *fname, MATRIX *M) {
 		fprintf(stderr, "Error opening %s\n", fname);
 		return -1;
 	}
-	if ( fscanf(fptr, "%d %d %d\n", &M->rows, &M->cols, &M->q) < 0 ) {
+	if ( fscanf(fptr, "%u %u %u\n", &M->rows, &M->cols, &M->q) != 3 ) {
 		fprintf(stderr, "Error reading header of %s\n", fname);
-	}
-	if (M->rows < 32768) {
-		M->m = (unsigned int **)malloc(M->rows * sizeof(unsigned int *));
-	} else {
-		fprintf(stderr, "Error: max number of cols exceeded.\n");
+		fclose(fptr);
 		return -1;
 	}
-	for (i=0; i<M->rows; i++) 
-		M->m[i] = (unsigned int *)malloc(M->cols * sizeof(unsigned int));
+	if (M->rows == 0 || M->rows >= 32768) {
+		fprintf(stderr, "Error: number of rows must be between 1 and 32767.\n");
+		fclose(fptr);
+		return -1;
+	}
+	if (M->cols == 0 || M->cols < M->rows) {
+		fprintf(stderr, "Error: number of columns must be at least the number of rows.\n");
+		fclose(fptr);
+		return -1;
+	}
+	M->m = alloc_array(M->rows, sizeof(unsigned int *), "generator matrix");
+	if (!M->m) {
+		fclose(fptr);
+		return -1;
+	}
+	for (i=0; i<M->rows; i++) {
+		M->m[i] = alloc_array(M->cols, sizeof(unsigned int), "generator matrix row");
+		if (!M->m[i]) {
+			fclose(fptr);
+			return -1;
+		}
+	}
 	for (i=0; i<M->rows; i++) {
 		for (j=0; j<M->cols; j++) {
-			if ( fscanf(fptr, "%d ", &M->m[i][j]) < 0 ) {
+			if ( fscanf(fptr, "%u ", &M->m[i][j]) != 1 ) {
 				fprintf(stderr, "Error reading data from %s\n", fname);
+				fclose(fptr);
+				return -1;
 			}
 		}
 	}
 
+	fclose(fptr);
 	return 0;
 }
 

--- a/src/ctjhai/types.h
+++ b/src/ctjhai/types.h
@@ -32,13 +32,13 @@ typedef enum { C_0MOD2 = 1, C_1MOD2, C_3MOD4, C_0MOD4, C_0MOD3 } mod_t;
 
 typedef struct {
 	mod_t weight_constraint;
-	unsigned short known_lower_bound;
-	unsigned short lower_bound, upper_bound;
-	unsigned short displayed_lower_bound;
-	unsigned short info_weight_completed;
-	unsigned short max_info_weight_req;
-	unsigned short ith_matrix;
-	unsigned short matrices_req;
+	unsigned int known_lower_bound;
+	unsigned int lower_bound, upper_bound;
+	unsigned int displayed_lower_bound;
+	unsigned int info_weight_completed;
+	unsigned int max_info_weight_req;
+	unsigned int ith_matrix;
+	unsigned int matrices_req;
 } INFO;
 /*-----------------------------------------------------------------*/
 


### PR DESCRIPTION
> [!NOTE]
> Stacked on #132 — that is the base branch, so the diff here is just the one commit. Merge #132 first and this retargets to master on its own.

### #46: lengths truncated to 16 bits

Reproduced first, and it is worse than the report: the issue says guava returns 0, but on master it prints `There are 0 generator matrices` and then segfaults.

The cause is checkable. `PACKED_MATRIX_GF2.nMatrices` is `unsigned short`, and for the family of codes in the issue that count is exactly `n - k`:

| length | matrices reported |
| --- | --- |
| 103 | 100 |
| 1003 | 1000 |
| 60003 | 60000 |
| 65539 | **0** |

`block_length` truncates 65539 to 3 the same way, and the enumeration loops accumulate codeword weights in a `short` that cannot hold a weight up to n.

Widening the lengths, counts and weights to `unsigned int` — enough for any code GAP can hold — gives the right answer:

```
$ minimum-weight long        # 3 x 65539 over GF(2), rows [1]*65536 + e_i
There are 65536 generator matrices, ranks : 3 1 1 ...
Minimum weight: 2
```

The GF(3) arithmetic tables stay 16-bit: they hold field elements, not lengths.

### #57: the overflow was one symptom of an unvalidated read

`generator_matrix()` trusted the file completely. It read `%d` into `unsigned int` fields; compared the `fscanf` result against `< 0`, so a header with one of three values read passed; sized allocations by multiplying an attacker-chosen column count by `sizeof(unsigned int)`; never checked a `malloc`; and `main` discarded its return value, so a failed read fell through into the computation.

It now validates the header, multiplies in `size_t` and rejects what would wrap, reports allocation failure, and stops on a short read. Each of these is rejected cleanly instead of crashing:

```
garbage
0 10 2
2 5 2 / 1 0 1      (body shorter than the header claims)
```

### Testing

The regression test needs n ≥ 65536, which is inherently a ~15s run, and malformed files the GAP code never produces — so it is a `make check-programs` target rather than a `tst/*.tst` file, following kbmag's `check-standalone`, and it runs in CI. I checked it fails against the unfixed binary.

The GAP test suite is unchanged, and `MinimumWeight` still agrees on Hamming, both Golay codes, Reed-Muller and BCH over GF(2) and GF(3).

Fixes #46
Fixes #57
