### PR TITLE
Use the library's CosetLeadersMatFFE where it works

### DIFF
--- a/lib/codenorm.gi
+++ b/lib/codenorm.gi
@@ -76,7 +76,7 @@ function ( code, i )
         for j in [ 1 .. Length( els ) ] do
             subcode[ j ] := CoordinateSubCode( code, j, els[ j ] );
         od;
-        for w in Codeword( CosetLeadersMatFFE( CheckMat( code ),
+        for w in Codeword( GuavaCosetLeadersMatFFE( CheckMat( code ),
                            LeftActingDomain( code ) ) ) do
             for j in [ 1 .. Length( els ) ] do
                 if subcode[ j ] = false then

--- a/lib/codeops.gi
+++ b/lib/codeops.gi
@@ -2828,10 +2828,22 @@ function(C)
     return GUAVA_TEMP_VAR;
 end);
 
-#This is a copy of CosetLeadersMatFFE(mat,f) from gap/lib/listcoef.gi
-# for experimentation purposes...
+# CosetLeadersMatFFE skipped cosets over fields of size 4 to 255, so the list
+# it returned had holes in it and CoveringRadius and SyndromeTable failed on
+# such codes.  GAP 4.16.0 fixed that (issue #104), so from there on this is
+# just the library function.
+if CompareVersionNumbers(GAPInfo.Version, "4.16.0") then
 
-InstallMethod(GuavaCosetLeadersMatFFE,"generic",IsCollsElms,
+InstallMethod(GuavaCosetLeadersMatFFE,"use the GAP library function",IsCollsElms,
+        [IsMatrix,IsFFECollection and IsField],0,
+        CosetLeadersMatFFE);
+
+else
+
+# On older GAP, fall back to a copy of CosetLeadersMatFFE with the branch that
+# had the bug disabled: correct, but without the speedup it gave.  Drop this
+# once GUAVA requires GAP >= 4.16.0.
+InstallMethod(GuavaCosetLeadersMatFFE,"work around the pre-4.16 library bug",IsCollsElms,
         [IsMatrix,IsFFECollection and IsField],0,
         function(mat,f)
     local q, leaders, tofind, n,m, t, vl, i, felts, fds,
@@ -2934,4 +2946,6 @@ InstallMethod(GuavaCosetLeadersMatFFE,"generic",IsCollsElms,
     Unbind(leaders[q^m+1]);
     return leaders;
 end);
+
+fi;
 


### PR DESCRIPTION
`GuavaCosetLeadersMatFFE` is a copy of the library's `CosetLeadersMatFFE` with some buggy parts commented out. GAP 4.16.0 fixed the library function, so starting from that version, we define `GuavaCosetLeadersMatFFE` as a synonym for `CosetLeadersMatFFE`

Since GUAVA still declares `GAP := ">= 4.8.0"`, the old code has to stay for older GAP versions. Bumping the requirement to 4.16.0 would let the whole `else` branch go.

Comparing the two directly on the fields the branch covers:

| code | copy | library |
| --- | --- | --- |
| random [10,4] over GF(4) | 3.95 ms | 0.31 ms |
| random [9,3] over GF(8) | 278 ms | 26 ms |

One more thing: `CoordinateNorm` in `lib/codenorm.gi` called `CosetLeadersMatFFE` directly rather than going through `GuavaCosetLeadersMatFFE`, so on the fields the workaround exists for it kept hitting the bug. It now uses `GuavaCosetLeadersMatFFE` like the other three call sites.

Fixes #104

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>