### PR TITLE
Compute the BCH bound RootsCode claims to compute

### DIFF
--- a/doc/guava.xml
+++ b/doc/guava.xml
@@ -2915,7 +2915,7 @@ a cyclic [16,12,5]3..4 Reed-Solomon code over GF(17)
 gap> RootsOfCode( C1 );
 [ Z(17), Z(17)^2, Z(17)^3, Z(17)^4 ]
 gap> C2 := RootsCode( 16, last );
-a cyclic [16,12,3..5]3..4 code defined by roots over GF(17)
+a cyclic [16,12,5]3..4 code defined by roots over GF(17)
 gap> C1 = C2;
 true
 </Example>
@@ -5974,7 +5974,7 @@ extension field of <M>GF(q)</M>. It uses the set of the powers of
 gap> a := PrimitiveUnityRoot( 3, 14 );
 Z(3^6)^52
 gap> C1 := RootsCode( 14, [ a^0, a, a^3 ] );
-a cyclic [14,7,3..6]3..7 code defined by roots over GF(3)
+a cyclic [14,7,4..6]3..7 code defined by roots over GF(3)
 gap> MinimumDistance( C1 );
 4
 gap> b := PrimitiveUnityRoot( 2, 15 );
@@ -5984,7 +5984,7 @@ a cyclic [15,7,5]3..5 code defined by roots over GF(2)
 gap> C2 = BCHCode( 15, 5, GF(2) );
 true
 gap> C3 := RootsCode( 4, [ 1, 2 ], 5 );
-a cyclic [4,2,2..3]2 code defined by roots over GF(5)
+a cyclic [4,2,3]2 code defined by roots over GF(5)
 gap> RootsOfCode( C3 );
 [ Z(5), Z(5)^2 ]
 gap> C3 = ReedSolomonCode( 4, 3 );

--- a/lib/codegen.gi
+++ b/lib/codegen.gi
@@ -1900,7 +1900,7 @@ end);
 
 InstallMethod(RootsCode, "method for n, rootlist, field", true, [IsInt, IsList, IsField], 0,
 function(n, L, F)
-    local g, C, num, power, p, q, z, i, j, rootslist, powerlist, max, cc, CC, CCz;
+    local g, C, num, a, q, z, i, j, rootslist, powers, powerlist, max, cc, CC, CCz;
     L := Set(L);
     q := Size(Field(L));
     z := Z(q);
@@ -1908,8 +1908,10 @@ function(n, L, F)
     if List(L, i->i^n) <> NullVector(Length(L), F) + z^0 then
        Error("powers must all be n'th roots of unity");
     fi;
-    p := Characteristic(Field(L));
-    CC:=CyclotomicCosets(p,q-1);
+    # conjugation over F sends a root x to x^|F|, so the roots of a
+    # polynomial over F come in cyclotomic cosets under |F| -- under the
+    # characteristic only when F is prime
+    CC:=CyclotomicCosets(Size(F),q-1);
     CCz:=List(CC,cc->List(cc,j->z^j));
     ##  this is the set of cyclotomic cosets, represented
     ##  as powers of a primitive element z
@@ -1933,17 +1935,21 @@ function(n, L, F)
     rootslist := Set(rootslist);
     SetRootsOfCode(C, rootslist);
 
-    # Find the largest number of successive powers for BCH bound
-    max := 1;
-    i := 1;
-    num := Length(powerlist);
-    for z in [2..num] do
-        if powerlist[z] <> powerlist[i] + z-i then
-            max := Maximum(max, z - i);
-            i := z;
-        fi;
+    # BCH bound: one more than the longest run of consecutive powers of a
+    # primitive n-th root of unity among the roots, counted cyclically.
+    a := PrimitiveUnityRoot(Size(F), n);
+    powers := Set(List(rootslist, i->LogFFE(i, a)));
+    max := 0;
+    for i in powers do
+        num := 0;
+        j := i;
+        while num < n and (j mod n) in powers do
+            num := num + 1;
+            j := j + 1;
+        od;
+        max := Maximum(max, num);
     od;
-    C!.lowerBoundMinimumDistance := Maximum(max, num+1 - i) + 1;
+    C!.lowerBoundMinimumDistance := max + 1;
 return C;
 end);
 

--- a/tst/guava04.tst
+++ b/tst/guava04.tst
@@ -455,7 +455,7 @@ a cyclic [16,12,5]3..4 Reed-Solomon code over GF(17)
 gap> RootsOfCode( C1 );
 [ Z(17), Z(17)^2, Z(17)^3, Z(17)^4 ]
 gap> C2 := RootsCode( 16, last );
-a cyclic [16,12,3..5]3..4 code defined by roots over GF(17)
+a cyclic [16,12,5]3..4 code defined by roots over GF(17)
 gap> C1 = C2;
 true
 

--- a/tst/guava05.tst
+++ b/tst/guava05.tst
@@ -368,7 +368,7 @@ x-Z(3)^0
 gap> a := PrimitiveUnityRoot( 3, 14 );
 Z(3^6)^52
 gap> C1 := RootsCode( 14, [ a^0, a, a^3 ] );
-a cyclic [14,7,3..6]3..7 code defined by roots over GF(3)
+a cyclic [14,7,4..6]3..7 code defined by roots over GF(3)
 gap> MinimumDistance( C1 );
 4
 gap> b := PrimitiveUnityRoot( 2, 15 );
@@ -378,7 +378,7 @@ a cyclic [15,7,5]3..5 code defined by roots over GF(2)
 gap> C2 = BCHCode( 15, 5, GF(2) );
 true
 gap> C3 := RootsCode( 4, [ 1, 2 ], 5 );
-a cyclic [4,2,2..3]2 code defined by roots over GF(5)
+a cyclic [4,2,3]2 code defined by roots over GF(5)
 gap> RootsOfCode( C3 );
 [ Z(5), Z(5)^2 ]
 gap> C3 = ReedSolomonCode( 4, 3 );


### PR DESCRIPTION
`RootsCode`'s BCH-bound loop was written for a list of exponents, but `powerlist` holds cyclotomic cosets — lists of field elements. So `powerlist[i] + z-i` added an integer to a list of FFEs, which GAP coerces into the field and adds elementwise, turning `[b,b²,b⁴,b⁸]` into `[b⁴,b⁸,b,b²]`. The test was true on every iteration, the run length never rose above 1, and the bound came out as 2 for every input. It now takes the logs of the roots to a primitive n-th root of unity and finds the longest run of consecutive exponents, cyclically.

Fixing that exposed a second bug: the cosets were taken under the characteristic rather than `|F|`. Conjugation over `F` sends a root `x` to `x^|F|`, so over a non-prime `F` the wrong roots were collected — `RootsCode(5,[a^2],GF(4))` built a generator polynomial vanishing at `a` and `a^4`, not at the `a^2` it was asked for, and `RootsOfCode` reported roots that were not roots of it. For prime `F` nothing changes.

Four documented outputs change. The `[14,7]` code over GF(3) becomes `4..6`, not the `3..6` the issue quotes — the run `13,0,1` wraps around and the old documented value missed it. The other three now pin the distance exactly. In all four the new bound equals the true minimum distance.

| example | before | now | true d |
| --- | --- | --- | --- |
| `RootsCode(14,[a^0,a,a^3])` over GF(3) | `[14,7,2..6]` | `[14,7,4..6]` | 4 |
| `RootsCode(15,[b,b^2,b^3,b^4])` over GF(2) | `[15,7,2..5]` | `[15,7,5]` | 5 |
| `RootsCode(4,[1,2],5)` | `[4,2,2..3]` | `[4,2,3]` | 3 |
| `RootsCode(16, RootsOfCode(ReedSolomonCode(16,5)))` | `[16,12,3..5]` | `[16,12,5]` | 5 |

Over 1534 `RootsCode`s across ten (q,n) pairs, no bound exceeds the true minimum distance and 1263 are tight.

Fixes #105
