### PR TITLE
Return the one cyclotomic coset that exists mod 1

### DIFF
--- a/lib/util.gi
+++ b/lib/util.gi
@@ -135,7 +135,8 @@ function(q, n)
     res := [[0]];
     nrelements := 1;
     elements := Set([1..n-1]);
-    repeat
+    # for n = 1 the class of 0 is all there is, so this must not run at all
+    while nrelements < n do
         start := elements[1];
         addel := start;
         set := [];
@@ -146,7 +147,7 @@ function(q, n)
             nrelements := nrelements + 1;
         until addel = start;
         Add(res, set);
-    until nrelements >= n;
+    od;
     return res;
 end);
 

--- a/tst/bugfix.tst
+++ b/tst/bugfix.tst
@@ -64,3 +64,18 @@ true
 gap> r := Codeword([1,0,2,2,0,2,2,2,0,0,1,0,2], C);;   # two errors
 gap> Decodeword(C, r) = c;
 true
+
+##
+## CyclotomicCosets(q,1) indexed an empty list instead of returning the one
+## class there is.  RootsCode reached that whenever the roots it was given
+## generated only the prime field, so 1 as the sole root always crashed.
+##
+gap> CyclotomicCosets(2,1);
+[ [ 0 ] ]
+gap> CyclotomicCosets(4,1);
+[ [ 0 ] ]
+gap> C := RootsCode(7, [Z(2)^0], GF(2));;
+gap> Dimension(C);
+6
+gap> MinimumDistance(C);
+2


### PR DESCRIPTION
`CyclotomicCosets` built its result with a `repeat`-`until`, so it read `elements[1]` before testing whether anything was left to classify. Mod 1 the class of 0 is all there is and that list starts out empty, so `CyclotomicCosets(q,1)` died on it for every `q`. A `while` loop tests first and leaves `n >= 2` untouched.

`RootsCode` reached this whenever the roots it was handed generated no more than the prime field, since it takes cosets mod `|Field(L)|-1` — so asking for the code with 1 as its only root always crashed:

```
gap> RootsCode(7, [Z(2)^0], GF(2));
Error, List Element: <list>[1] must have an assigned value
```

That now gives the even-weight `[7,6,2]` code, which is right: with 1 as the only root the generator polynomial is `x+1`.

Independent of #137 — different files, and the two examples added to `tst/bugfix.tst` give the same answer with or without it.
