### PR TITLE
Know the minimum distance of a one-dimensional code

### DIFF
--- a/lib/codegen.gi
+++ b/lib/codegen.gi
@@ -483,7 +483,13 @@ function(G, name, F)
     SetGeneratorMat(C, G);
     SetWordLength(C, n);
     C!.upperBoundMinimumDistance := dmax;
-    C!.lowerBoundMinimumDistance := 1;
+    if Length(L) = 1 then
+        # the codewords are the scalar multiples of the one generator, so they
+        # all have its weight
+        C!.lowerBoundMinimumDistance := dmax;
+    else
+        C!.lowerBoundMinimumDistance := 1;
+    fi;
     C!.name := name;
     return C;
 end);


### PR DESCRIPTION
`GeneratorMatCode` records the least weight among the generators as an upper bound on the minimum distance, and 1 as the lower bound. With a single generator the codewords are its scalar multiples, which all have its weight, so there the upper bound *is* the minimum distance.

Two documented codes become exact again:

```
ToricCode([[1,0],[3,4]],GF(3))          [4,1,1..4]  ->  [4,1,4]
GeneratorMatCode([[1,1,1]]*Z(2)^0,GF(2))  [3,1,1..3]  ->  [3,1,3]
```

Both are covered by the extracted manual tests, which go from failing to passing — the suite drops from 61 failures to 59, and nothing else moves.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>