### PR TITLE
Let CodeDistanceEnumerator take the word as a plain list

### DIFF
--- a/lib/codemisc.gi
+++ b/lib/codemisc.gi
@@ -42,7 +42,20 @@ InstallMethod(CodeDistanceEnumerator, "unrestricted code, codeword", true,
 function( code, word )
 
     word := Codeword( word, code );
+    return LaurentPolynomialByCoefficients(
+        ElementsFamily(FamilyObj( Rationals )),
+        DistancesDistribution( code, word ),  0  );
 
+end);
+
+# the word may also be given as a plain list, as the manual does.  This
+# repeats the method above rather than delegating to it: a codeword is a list
+# too, so delegating would risk coming straight back here.
+InstallOtherMethod(CodeDistanceEnumerator, "unrestricted code, list", true,
+    [IsCode, IsList], 0,
+function( code, word )
+
+    word := Codeword( word, code );
     return LaurentPolynomialByCoefficients(
         ElementsFamily(FamilyObj( Rationals )),
         DistancesDistribution( code, word ),  0  );

--- a/tst/bugfix.tst
+++ b/tst/bugfix.tst
@@ -79,3 +79,14 @@ gap> Dimension(C);
 6
 gap> MinimumDistance(C);
 2
+
+##
+## CodeDistanceEnumerator only had a method for a codeword, so the plain list
+## the manual passes it found no method at all
+##
+gap> C := HammingCode(3,GF(2));;
+gap> CodeDistanceEnumerator(C, [0,0,0,0,0,0,1])
+>      = CodeDistanceEnumerator(C, Codeword([0,0,0,0,0,0,1],GF(2)));
+true
+gap> CodeDistanceEnumerator(C, [1,1,1,1,1,1,1]) = CodeWeightEnumerator(C);
+true


### PR DESCRIPTION
`CodeDistanceEnumerator`'s only method asked for a codeword, so the plain list the manual passes it found no method at all:

```
gap> CodeDistanceEnumerator( HammingCode( 3, GF(2) ),[0,0,0,0,0,0,1] );
Error, no method found!
```

The method body already converted its argument with `Codeword`, which takes lists and strings, so only the filter stood in the way. The new method repeats that body rather than delegating to the old one: a codeword is a list too, so delegating would risk coming straight back to it.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>