### PR TITLE
add architecture dependent options

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -13,8 +13,11 @@ CJDIR   = src/ctjhai
 OBJDIR  = obj
 BINDIR  = bin/$(GAPARCH)
 
-CC ?= gcc
-CFLAGS ?= -O2 -g
+CC ?= @CC@
+CFLAGS ?= @CFLAGS@
+
+# Linker flags; configure will substitute a sensible default for the host
+LDFLAGS ?= @LDFLAGS@
 
 EXTRA_CFLAGS += -Wall
 # Leon's code is from the early 1990s and warns about style throughout;
@@ -48,13 +51,13 @@ all: $(addprefix $(BINDIR)/,$(PROGS))
 # how to build them
 #
 $(addprefix $(BINDIR)/,$(LEON_PROGS)): $(BINDIR)/%: $(OBJDIR)/leon/%.o $(OBJDIR)/libleon.a | $(BINDIR)
-	$(CC) $(EXTRA_CFLAGS) $(LDFLAGS) -o $@ $^
+	$(CC) $(EXTRA_CFLAGS) -o $@ $^ $(LDFLAGS)
 
 $(BINDIR)/minimum-weight: $(CJ_OBJS) | $(BINDIR)
-	$(CC) $(EXTRA_CFLAGS) $(LDFLAGS) -o $@ $^ -lm
+	$(CC) $(EXTRA_CFLAGS) -o $@ $^ $(LDFLAGS) -lm
 
 $(BINDIR)/leonconv: $(OBJDIR)/leonconv.o | $(BINDIR)
-	$(CC) $(EXTRA_CFLAGS) $(LDFLAGS) -o $@ $^
+	$(CC) $(EXTRA_CFLAGS) -o $@ $^ $(LDFLAGS)
 
 $(OBJDIR)/libleon.a: $(LEON_LIBOBJS)
 	$(AR) cr $@ $^

--- a/configure
+++ b/configure
@@ -33,7 +33,25 @@ fi
 echo "Using settings from $GAPPATH/sysinfo.gap"
 rm -f Makefile
 . "$GAPPATH/sysinfo.gap"
+# decide sensible defaults for compiler and flags based on host
+CC_DEFAULT=gcc
+CFLAGS_DEFAULT='-O2 -g'
+LDFLAGS_DEFAULT=''
+case "`uname -s`" in
+  Darwin*)
+    CC_DEFAULT=/usr/bin/clang
+    # macOS generally links system libraries automatically; leave LDFLAGS empty
+    LDFLAGS_DEFAULT=''
+    ;;
+  *)
+    CC_DEFAULT=gcc
+    ;;
+esac
+
 sed \
     -e "s;@GAPARCH@;$GAParch;g" \
     -e "s;@GAPPATH@;$GAPPATH;g" \
+    -e "s;@CC@;$CC_DEFAULT;g" \
+    -e "s;@CFLAGS@;$CFLAGS_DEFAULT;g" \
+    -e "s;@LDFLAGS@;$LDFLAGS_DEFAULT;g" \
     Makefile.in >Makefile


### PR DESCRIPTION
These changes are the result of a long session with VSCode's GPT-5 chat.  I was having trouble compiling on a mac - which I think ultimately came down to a corrupted conda install on my machine - but we explored adding architecture specific options in ./configure and these are the results