### PR TITLE
Ask whether the subcodes of GeneralizedCodeNorm are subcodes

### DIFF
--- a/lib/codenorm.gi
+++ b/lib/codenorm.gi
@@ -264,7 +264,7 @@ function ( arg )
             Error( "GeneralizedCodeNorm: length of code ", i,
                    " is not equal to the length of <code>" );
         fi;
-        if not ( arg[ i + 1 ] in arg[ 1 ] ) then
+        if not IsSubset( arg[ 1 ], arg[ i + 1 ] ) then
             Error( "GeneralizedCodeNorm: code ", i,
                    " is not a subcode of code." );
         fi;


### PR DESCRIPTION
`GeneralizedCodeNorm` rejected every set of subcodes it was given:

```
gap> GeneralizedCodeNorm( ham, c, d, e );
Error, GeneralizedCodeNorm: code 1 is not a subcode of code.
```

The check was

```gap
if not ( arg[i+1] in arg[1] ) then
    Error( "GeneralizedCodeNorm: code ", i, " is not a subcode of code." );
```

`arg[i+1] in arg[1]` asks whether the code *object* is an element of `arg[1]`, and the elements of a code are codewords, so it is false for any code — the function stopped on the first subcode every time. `IsSubset` asks what the error message describes.

The documented example gives 4 again. Codes that genuinely are not subcodes are still rejected — checked with a code over the wrong field and with a same-length code that properly contains `ham`.
