### PR TITLE
Give LowerBoundGilbertVarshamov an answer for distance 1

### DIFF
--- a/lib/bounds.gi
+++ b/lib/bounds.gi
@@ -17,6 +17,12 @@
 ## added 9-2004 by wdj; debugged 2009 by Jack Schmidt
 InstallMethod(LowerBoundGilbertVarshamov, "n, d, q", true, [IsInt, IsInt, IsInt], 0,
 function(n, d, q)
+   # the sphere of radius d-2 is empty for d = 1, so the quotient below is not
+   # defined there.  Every code has minimum distance at least 1, so the whole
+   # space is the bound.
+   if d <= 1 then
+      return q^n;
+   fi;
    return q^LogInt(Int((q^n-1)/SphereContent(n-1,d-2,q)),q);
 end);
 

--- a/tst/bugfix.tst
+++ b/tst/bugfix.tst
@@ -90,3 +90,14 @@ gap> CodeDistanceEnumerator(C, [0,0,0,0,0,0,1])
 true
 gap> CodeDistanceEnumerator(C, [1,1,1,1,1,1,1]) = CodeWeightEnumerator(C);
 true
+
+##
+## LowerBoundGilbertVarshamov divided by the size of a sphere of radius d-2,
+## which is empty when d is 1
+##
+gap> LowerBoundGilbertVarshamov(4,1,2);
+16
+gap> LowerBoundGilbertVarshamov(3,1,3);
+27
+gap> List([2..8], n -> LowerBoundGilbertVarshamov(n,2,2) = 2^(n-1));
+[ true, true, true, true, true, true, true ]


### PR DESCRIPTION
The bound divides by the size of a sphere of radius `d-2`, and that sphere is empty when `d` is 1, so every call with `d = 1` died:

```
gap> LowerBoundGilbertVarshamov(3,1,2);
Error, Rational operations: <divisor> must not be zero
```

Minimum distance 1 is not an odd thing to ask about — it is what the whole space has — and the bound there is `q^n`, which the whole space attains. Returning that avoids the division.

Checked that `d = 2` still gives `q^(n-1)` for n up to 8, and that the five values the manual records for this function are unchanged.
