### PR TITLE
Read the generator bound off a reduced generator matrix

### DIFF
--- a/doc/guava.xml
+++ b/doc/guava.xml
@@ -6507,7 +6507,7 @@ x^21+x^20+x^19-x^15-x^14-x^12+x^11-x^8+x^5+x^4-x^3-x^2
 gap> L3 := PolyCodeword( Codeword("22021011202221111020021",GF(3)) );
 x^22-x^21-x^18+x^16+x^15+x^14+x^13-x^12-x^11-x^10-x^8+x^7+x^6+x^4-x^3-x-Z(3)^0
 gap> C := QuasiCyclicCode( [L1, L2, L3], 23, GF(3) );
-a linear [69,12,1..38]27..46 quasi-cyclic code over GF(3)
+a linear [69,12,1..36]27..46 quasi-cyclic code over GF(3)
 gap> MinimumDistance(C);
 34
 gap> Display(C);
@@ -8074,7 +8074,7 @@ gap> indets := IndeterminatesOfPolynomialRing(R);
 gap> x:=indets[1];; y:=indets[2];;
 gap> P:=AffinePointsOnCurve(y^2-x^11+x,R,F);;
 gap> C:=OnePointAGCode(y^2-x^11+x,P,15,R);
-a linear [11,8,1..0]2..3  one-point AG code over GF(11)
+a linear [11,8,1..4]2..3  one-point AG code over GF(11)
 gap> MinimumDistance(C);
 4
 gap> Pts:=List([1,2,4,6,7,8,9,10,11],i->P[i]);;
@@ -10218,8 +10218,8 @@ LowerBoundSpherePacking(3,3,2);
 In this form, <C>UpperBoundMinimumDistance</C> returns an upper bound for the
 minimum distance of code <A>C</A>. For unrestricted codes, it just returns the
 word length. For linear codes, it takes the minimum of the possibly known
-value from the method of construction, the weight of the generators, and
-the value from the table (see
+value from the method of construction, the least weight among the rows of
+a reduced generator matrix, and the value from the table (see
 <Ref Label="BoundsMinimumDistance" Style="Number"/>).
 <P/>
 This command can also be called using the syntax

--- a/lib/codeops.gi
+++ b/lib/codeops.gi
@@ -989,12 +989,23 @@ end);
 InstallMethod(MinimumWeightOfGenerators, "linear codes", true,
     [IsLinearCode], 0,
 function(C)
-    local zero, mwg, sum, element, row;
+    local zero, mwg, sum, element, row, G;
     zero := Zero(LeftActingDomain(C));
     mwg := WordLength(C);
     if Dimension(C) > 0 then
         # minimumWeightOfGenerators for null codes is n
-        for row in GeneratorMat(C) do
+        #
+        # Reduce first.  Every generator is a codeword, so any of them bounds
+        # the minimum distance, but which ones we are holding is an accident
+        # of how the code was built, and of how GAP happens to reduce.  The
+        # reduced row echelon form is determined by the code and its
+        # coordinate order alone, so the bound stops moving when either
+        # changes.  It is not systematically tighter -- on random codes the
+        # two are within a coin flip of each other -- but it is the same
+        # answer every time.
+        G := Filtered(TriangulizedMat(MutableCopyMat(GeneratorMat(C))),
+                      row -> not IsZero(row));
+        for row in G do
             sum := 0;
             for element in row do
                 if element <> zero then

--- a/tst/guava.tst
+++ b/tst/guava.tst
@@ -622,7 +622,7 @@ gap> P:=AffinePointsOnCurve(y^2-x^11+x,R,F);
   [ Z(11)^3, 0*Z(11) ], [ Z(11)^2, 0*Z(11) ], [ Z(11), 0*Z(11) ], 
   [ Z(11)^0, 0*Z(11) ], [ 0*Z(11), 0*Z(11) ] ]
 gap> C:=OnePointAGCode(y^2-x^11+x,P,15,R);
-a linear [11,8,1..0]2..3  one-point AG code over GF(11)
+a linear [11,8,1..4]2..3  one-point AG code over GF(11)
 gap> Cd := DualCode(C);
 a linear [11,3,1..9]6..8 dual code
 gap> MinimumDistance(Cd);

--- a/tst/guava05.tst
+++ b/tst/guava05.tst
@@ -549,7 +549,7 @@ x^21+x^20+x^19-x^15-x^14-x^12+x^11-x^8+x^5+x^4-x^3-x^2
 gap> L3 := PolyCodeword( Codeword("22021011202221111020021",GF(3)) );
 x^22-x^21-x^18+x^16+x^15+x^14+x^13-x^12-x^11-x^10-x^8+x^7+x^6+x^4-x^3-x-Z(3)^0
 gap> C := QuasiCyclicCode( [L1, L2, L3], 23, GF(3) );
-a linear [69,12,1..38]27..46 quasi-cyclic code over GF(3)
+a linear [69,12,1..36]27..46 quasi-cyclic code over GF(3)
 gap> MinimumDistance(C);
 34
 gap> Display(C);


### PR DESCRIPTION
> [!NOTE]
> A proposal rather than a fix — @osj1961, this is for you to weigh up and merge or discard. Stacked on #147, so the diff here is the one commit.

`UpperBoundMinimumDistance` for a linear code is the smallest of three things: a value the constructor may have recorded, the table bound for `(n,k,q)`, and `MinimumWeightOfGenerators` — the least weight among the rows of whatever generator matrix is stored. The third term is sound, since every generator is a codeword, but it depends on *which* generators we happen to be holding, and so on how GAP reduces. That is why the manual's quasi-cyclic bound drifted from 37 to 38 with no table entry and no GUAVA code having changed: `[68,11,38,"Gur"]` has read 38 since the first commit, and 37 is not reachable by shortening (38) or puncturing (39). It came from the generator term, on a basis GAP no longer produces.

This reduces before reading the weights off. The reduced row echelon form is determined by the code and its coordinate order alone, so the bound stops moving. Checked rather than assumed: eight random bases of that code give **one** distinct `TriangulizedMat`.

### It is not tighter, it is stable

On random codes the two are within a coin flip — over 24 codes the reduced form was tighter 9 times, equal 3, worse 12. It does help on the structured case that prompted this, where the code's own generators are far from minimal:

| | stored rows | reduced | table | true `d` |
| --- | --- | --- | --- | --- |
| quasi-cyclic `[69,12]` GF(3) | 40 | **36** | 38 | 34 |
| BCH(31,11), Golay(23), RM(2,5) | tight already | same | same | same |

So the argument is determinism, not sharpness. If sharpness is what's wanted, the next rung is the least weight over several *disjoint* information sets — which is the first step of Brouwer–Zimmermann, and which `src/ctjhai/minimum-weight.c` already assembles.

### Cost

One Gaussian elimination, and `MinimumWeightOfGenerators` is an attribute, so it is paid once per code and cached. Cyclic codes never reach this method at all — theirs already uses the generator polynomial, which is canonical. Measured: 0.4 ms for `[69,12]`, 12 ms for a random `[400,200]`, 45 ms for `[800,400]`, all within noise of the unreduced version.

### A bug fixed on the way, now split out as #149

Skipping zero rows. `OnePointAGCode` stores eleven generators for an eight-dimensional code, three of them zero, so the bound was **0** and the manual recorded `a linear [11,8,1..0]`. An upper bound of 0 on a minimum distance is impossible. It now reads `1..4`, the Singleton bound for those parameters. That part is worth keeping even if the reduction is not, so it is now its own PR, #149 — if that lands first this one will be rebased to drop it and propose only the reduction.

### What changes

Two documented bounds: the one above, and the quasi-cyclic code from `1..38` to `1..36`. The sentence in `UpperBoundMinimumDistance` that says "the weight of the generators" is reworded to match.

