### PR TITLE
Never bound the minimum distance by the zero codeword

### DIFF
--- a/doc/guava.xml
+++ b/doc/guava.xml
@@ -8074,7 +8074,7 @@ gap> indets := IndeterminatesOfPolynomialRing(R);
 gap> x:=indets[1];; y:=indets[2];;
 gap> P:=AffinePointsOnCurve(y^2-x^11+x,R,F);;
 gap> C:=OnePointAGCode(y^2-x^11+x,P,15,R);
-a linear [11,8,1..0]2..3  one-point AG code over GF(11)
+a linear [11,8,1..4]2..3  one-point AG code over GF(11)
 gap> MinimumDistance(C);
 4
 gap> Pts:=List([1,2,4,6,7,8,9,10,11],i->P[i]);;

--- a/lib/codeops.gi
+++ b/lib/codeops.gi
@@ -1001,7 +1001,11 @@ function(C)
                      sum := sum + 1;
                 fi;
             od;
-            if sum < mwg then
+            # The minimum distance is over the nonzero codewords, so a zero
+            # row is not a candidate.  Some constructors leave zero rows in
+            # the generator matrix -- OnePointAGCode returns eleven rows for
+            # an eight dimensional code -- and those made the bound 0.
+            if sum > 0 and sum < mwg then
                  mwg := sum;
             fi;
         od;

--- a/tst/guava.tst
+++ b/tst/guava.tst
@@ -622,7 +622,7 @@ gap> P:=AffinePointsOnCurve(y^2-x^11+x,R,F);
   [ Z(11)^3, 0*Z(11) ], [ Z(11)^2, 0*Z(11) ], [ Z(11), 0*Z(11) ], 
   [ Z(11)^0, 0*Z(11) ], [ 0*Z(11), 0*Z(11) ] ]
 gap> C:=OnePointAGCode(y^2-x^11+x,P,15,R);
-a linear [11,8,1..0]2..3  one-point AG code over GF(11)
+a linear [11,8,1..4]2..3  one-point AG code over GF(11)
 gap> Cd := DualCode(C);
 a linear [11,3,1..9]6..8 dual code
 gap> MinimumDistance(Cd);


### PR DESCRIPTION
`MinimumWeightOfGenerators` takes the least weight among the rows of the generator matrix, and `UpperBoundMinimumDistance` uses that as one of its three terms. Minimum distance is over the *nonzero* codewords, so a zero row is not a candidate — but the loop took it, and some constructors leave zero rows behind. `OnePointAGCode` returns eleven generators for an eight-dimensional code, three of them zero:

```
row weights: [ 11, 11, 11, 11, 11, 0, 11, 0, 11, 0, 11 ]
```

so the bound came out as 0, and both the manual and `tst/guava.tst` record

```
a linear [11,8,1..0]2..3  one-point AG code over GF(11)
```

An upper bound of 0 on a minimum distance cannot happen. It now reads `1..4` — and the `<Log>` that example sits in gives the distance as 4, so the bound is tight.

One line of behaviour, plus the two places that recorded the old value. The suite is otherwise unchanged.

Split out of #148 so it can be judged on its own: that one proposes reading the bound off a *reduced* generator matrix, which is a separate argument. If both land, #148 will be rebased to drop this part.
